### PR TITLE
fix(auth): log per-authenticator rejections instead of swallowing them

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -97,7 +97,7 @@ func Build(ctx context.Context, cfg *config.Config, logger *slog.Logger) (*Appli
 		oidcAuth = v
 		oidcConcrete = v
 	}
-	chain := auth.NewChain(cfg.Auth.AllowAnonymous, keyStore, oidcAuth).WithLogger(logger)
+	chain := auth.NewChain(cfg.Auth.AllowAnonymous, keyStore, oidcAuth).SetLogger(logger)
 
 	app := buildFromDeps(cfg, logger, chain, auditLog)
 	app.pool = pool

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -97,7 +97,7 @@ func Build(ctx context.Context, cfg *config.Config, logger *slog.Logger) (*Appli
 		oidcAuth = v
 		oidcConcrete = v
 	}
-	chain := auth.NewChain(cfg.Auth.AllowAnonymous, keyStore, oidcAuth)
+	chain := auth.NewChain(cfg.Auth.AllowAnonymous, keyStore, oidcAuth).WithLogger(logger)
 
 	app := buildFromDeps(cfg, logger, chain, auditLog)
 	app.pool = pool

--- a/pkg/auth/chain.go
+++ b/pkg/auth/chain.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"strings"
 )
 
@@ -15,15 +16,38 @@ type OIDCValidator interface {
 }
 
 // Chain attempts API key auth first, then OIDC bearer, then anonymous (when allowed).
+//
+// Each authenticator's rejection is logged at WARN before the chain falls
+// through, so operators can tell whether a 401 was caused by an expired
+// JWT, a JWKS miss, an unknown API key name, or simply the absence of any
+// credential. The token itself is never logged; only the underlying error.
 type Chain struct {
 	allowAnonymous bool
 	apiKeys        APIKeyStore
 	oidc           OIDCValidator
+	logger         *slog.Logger
 }
 
-// NewChain returns a chain. Either of apiKeys or oidc may be nil.
+// NewChain returns a chain. Either of apiKeys or oidc may be nil. The
+// returned chain logs auth failures via slog.Default(); call WithLogger
+// to attach a tagged logger.
 func NewChain(allowAnonymous bool, apiKeys APIKeyStore, oidc OIDCValidator) *Chain {
-	return &Chain{allowAnonymous: allowAnonymous, apiKeys: apiKeys, oidc: oidc}
+	return &Chain{
+		allowAnonymous: allowAnonymous,
+		apiKeys:        apiKeys,
+		oidc:           oidc,
+		logger:         slog.Default(),
+	}
+}
+
+// WithLogger returns the receiver after replacing the chain's logger.
+// Pass nil to fall back to slog.Default().
+func (c *Chain) WithLogger(l *slog.Logger) *Chain {
+	if l == nil {
+		l = slog.Default()
+	}
+	c.logger = l
+	return c
 }
 
 // Authenticate inspects the token stashed on ctx and returns the identity.
@@ -31,6 +55,12 @@ func NewChain(allowAnonymous bool, apiKeys APIKeyStore, oidc OIDCValidator) *Cha
 // Discrimination heuristic: a token starting with "ey" (typical JWT header) is
 // tried as an OIDC bearer first; everything else is tried as an API key first.
 // If both stores are configured, the second is attempted on miss.
+//
+// Auth failures from each configured store are logged at WARN before the
+// chain falls through. ErrNotAuthenticated is returned only when every
+// configured store rejected the token (or no token was present and
+// anonymous is off); the per-authenticator errors stay in the log so
+// operators can diagnose which validation step actually failed.
 func (c *Chain) Authenticate(ctx context.Context) (*Identity, error) {
 	tok := GetToken(ctx)
 	if tok == "" {
@@ -43,19 +73,39 @@ func (c *Chain) Authenticate(ctx context.Context) (*Identity, error) {
 	tryOIDCFirst := strings.HasPrefix(tok, "ey")
 
 	if tryOIDCFirst && c.oidc != nil {
-		if id, err := c.oidc.ValidateBearer(ctx, tok); err == nil {
+		id, err := c.oidc.ValidateBearer(ctx, tok)
+		if err == nil {
 			return id, nil
 		}
+		c.logAuthFailure("oidc", err)
 	}
 	if c.apiKeys != nil {
-		if id, err := c.apiKeys.Authenticate(ctx, tok); err == nil {
+		id, err := c.apiKeys.Authenticate(ctx, tok)
+		if err == nil {
 			return id, nil
 		}
+		c.logAuthFailure("apikey", err)
 	}
 	if !tryOIDCFirst && c.oidc != nil {
-		if id, err := c.oidc.ValidateBearer(ctx, tok); err == nil {
+		id, err := c.oidc.ValidateBearer(ctx, tok)
+		if err == nil {
 			return id, nil
 		}
+		c.logAuthFailure("oidc", err)
 	}
 	return nil, ErrNotAuthenticated
+}
+
+// logAuthFailure emits a single WARN line tagged with the authenticator
+// that rejected the token. The token itself is never included; only the
+// underlying error is, since validators construct their own messages
+// without echoing the credential bytes.
+func (c *Chain) logAuthFailure(method string, err error) {
+	if c.logger == nil {
+		return
+	}
+	c.logger.Warn("auth: token rejected",
+		"method", method,
+		"error", err,
+	)
 }

--- a/pkg/auth/chain.go
+++ b/pkg/auth/chain.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"regexp"
 	"strings"
+	"sync"
+	"time"
 )
 
 // ErrNotAuthenticated is returned when no auth method matched and anonymous is disabled.
@@ -17,32 +20,39 @@ type OIDCValidator interface {
 
 // Chain attempts API key auth first, then OIDC bearer, then anonymous (when allowed).
 //
-// Each authenticator's rejection is logged at WARN before the chain falls
-// through, so operators can tell whether a 401 was caused by an expired
-// JWT, a JWKS miss, an unknown API key name, or simply the absence of any
-// credential. The token itself is never logged; only the underlying error.
+// Each authenticator's rejection is recorded in the slog so operators can
+// tell whether a 401 was caused by an expired JWT, a JWKS miss, an
+// unknown API key name, or simply the absence of any credential. The
+// first failure per remote_addr within a 60-second window is emitted at
+// WARN; subsequent failures in the same window are emitted at DEBUG to
+// keep a noisy scanner from drowning the log. Token bytes embedded in
+// validator error messages are redacted (JWT-shape stripped) before the
+// log line is written.
 type Chain struct {
 	allowAnonymous bool
 	apiKeys        APIKeyStore
 	oidc           OIDCValidator
 	logger         *slog.Logger
+	rateLimit      *failureRateLimiter
 }
 
 // NewChain returns a chain. Either of apiKeys or oidc may be nil. The
-// returned chain logs auth failures via slog.Default(); call WithLogger
-// to attach a tagged logger.
+// returned chain logs auth failures via slog.Default(); call SetLogger to
+// attach a tagged logger.
 func NewChain(allowAnonymous bool, apiKeys APIKeyStore, oidc OIDCValidator) *Chain {
 	return &Chain{
 		allowAnonymous: allowAnonymous,
 		apiKeys:        apiKeys,
 		oidc:           oidc,
 		logger:         slog.Default(),
+		rateLimit:      newFailureRateLimiter(time.Minute),
 	}
 }
 
-// WithLogger returns the receiver after replacing the chain's logger.
-// Pass nil to fall back to slog.Default().
-func (c *Chain) WithLogger(l *slog.Logger) *Chain {
+// SetLogger replaces the chain's logger and returns the receiver for
+// chaining. Pass nil to fall back to slog.Default(). This mutates the
+// receiver; do not call it concurrently with Authenticate.
+func (c *Chain) SetLogger(l *slog.Logger) *Chain {
 	if l == nil {
 		l = slog.Default()
 	}
@@ -50,17 +60,24 @@ func (c *Chain) WithLogger(l *slog.Logger) *Chain {
 	return c
 }
 
+// WithLogger is a deprecated alias for SetLogger kept for binary
+// compatibility with the original PR. Prefer SetLogger.
+//
+// Deprecated: use SetLogger.
+func (c *Chain) WithLogger(l *slog.Logger) *Chain { return c.SetLogger(l) }
+
 // Authenticate inspects the token stashed on ctx and returns the identity.
 //
 // Discrimination heuristic: a token starting with "ey" (typical JWT header) is
 // tried as an OIDC bearer first; everything else is tried as an API key first.
 // If both stores are configured, the second is attempted on miss.
 //
-// Auth failures from each configured store are logged at WARN before the
-// chain falls through. ErrNotAuthenticated is returned only when every
-// configured store rejected the token (or no token was present and
-// anonymous is off); the per-authenticator errors stay in the log so
-// operators can diagnose which validation step actually failed.
+// Auth failures from each configured store are logged with method,
+// request_id, remote_addr, and a redacted error before the chain falls
+// through. ErrNotAuthenticated is returned only when every configured
+// store rejected the token (or no token was present and anonymous is
+// off); the per-authenticator errors stay in the log so operators can
+// diagnose which validation step actually failed.
 func (c *Chain) Authenticate(ctx context.Context) (*Identity, error) {
 	tok := GetToken(ctx)
 	if tok == "" {
@@ -77,35 +94,103 @@ func (c *Chain) Authenticate(ctx context.Context) (*Identity, error) {
 		if err == nil {
 			return id, nil
 		}
-		c.logAuthFailure("oidc", err)
+		c.logAuthFailure(ctx, "oidc", err)
 	}
 	if c.apiKeys != nil {
 		id, err := c.apiKeys.Authenticate(ctx, tok)
 		if err == nil {
 			return id, nil
 		}
-		c.logAuthFailure("apikey", err)
+		c.logAuthFailure(ctx, "apikey", err)
 	}
 	if !tryOIDCFirst && c.oidc != nil {
 		id, err := c.oidc.ValidateBearer(ctx, tok)
 		if err == nil {
 			return id, nil
 		}
-		c.logAuthFailure("oidc", err)
+		c.logAuthFailure(ctx, "oidc", err)
 	}
 	return nil, ErrNotAuthenticated
 }
 
-// logAuthFailure emits a single WARN line tagged with the authenticator
-// that rejected the token. The token itself is never included; only the
-// underlying error is, since validators construct their own messages
-// without echoing the credential bytes.
-func (c *Chain) logAuthFailure(method string, err error) {
-	if c.logger == nil {
-		return
+// logAuthFailure emits one log line per rejection. The first failure per
+// remote_addr per window is WARN; subsequent failures in the window are
+// DEBUG. Correlation fields (request_id, remote_addr) come from ctx so
+// the line can be joined against the matching audit_events row.
+func (c *Chain) logAuthFailure(ctx context.Context, method string, err error) {
+	level := slog.LevelDebug
+	remote := GetRemoteAddr(ctx)
+	if c.rateLimit.shouldWarn(remote) {
+		level = slog.LevelWarn
 	}
-	c.logger.Warn("auth: token rejected",
-		"method", method,
-		"error", err,
+	c.logger.LogAttrs(ctx, level, "auth: token rejected",
+		slog.String("method", method),
+		slog.String("error", redactTokenLikes(err.Error())),
+		slog.String("request_id", GetRequestID(ctx)),
+		slog.String("remote_addr", remote),
 	)
+}
+
+// jwtPattern matches three base64-url segments separated by dots, the
+// classic JWT shape. The minimum-length thresholds avoid stripping
+// short identifiers that happen to contain dots; real JWT segments are
+// well above 8 characters.
+var jwtPattern = regexp.MustCompile(`[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}`)
+
+// redactTokenLikes strips JWT-shaped substrings from a string so a
+// validator that quoted the rejected token in its error message can't
+// leak token bytes through the auth-failure log. The chain doesn't try
+// to scrub every conceivable secret shape; this is defense-in-depth on
+// top of the validator-error-doesn't-include-tokens contract.
+func redactTokenLikes(s string) string {
+	return jwtPattern.ReplaceAllString(s, "[redacted-jwt]")
+}
+
+// failureRateLimiter keeps one entry per remote_addr noting when the
+// last WARN-level auth-failure log was emitted for that source. The
+// first failure in a window earns WARN; subsequent failures in the
+// same window are demoted to DEBUG. Stale entries are evicted lazily
+// during shouldWarn calls so the map stays bounded under steady load.
+type failureRateLimiter struct {
+	window  time.Duration
+	mu      sync.Mutex
+	lastLog map[string]time.Time
+}
+
+func newFailureRateLimiter(window time.Duration) *failureRateLimiter {
+	if window <= 0 {
+		window = time.Minute
+	}
+	return &failureRateLimiter{
+		window:  window,
+		lastLog: make(map[string]time.Time),
+	}
+}
+
+// shouldWarn returns true the first time a key is seen within a window,
+// false on subsequent calls until the window elapses. Empty keys (no
+// remote_addr available) never rate-limit; every such call returns
+// true so requests without correlation context still surface.
+func (r *failureRateLimiter) shouldWarn(key string) bool {
+	if r == nil {
+		return true
+	}
+	if key == "" {
+		return true
+	}
+	now := time.Now()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// Opportunistic eviction; the ledger is small under normal load and
+	// this keeps it bounded under sustained pressure.
+	for k, t := range r.lastLog {
+		if now.Sub(t) > r.window {
+			delete(r.lastLog, k)
+		}
+	}
+	if last, ok := r.lastLog[key]; ok && now.Sub(last) <= r.window {
+		return false
+	}
+	r.lastLog[key] = now
+	return true
 }

--- a/pkg/auth/chain_test.go
+++ b/pkg/auth/chain_test.go
@@ -1,0 +1,187 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// fakeOIDC always returns the configured error from ValidateBearer.
+type fakeOIDC struct{ err error }
+
+func (f *fakeOIDC) ValidateBearer(_ context.Context, _ string) (*Identity, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &Identity{Subject: "alice", AuthType: "oidc"}, nil
+}
+
+// fakeAPIKeys returns the configured error from Authenticate.
+type fakeAPIKeys struct{ err error }
+
+func (f *fakeAPIKeys) Authenticate(_ context.Context, _ string) (*Identity, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &Identity{Subject: "key-bob", AuthType: "apikey"}, nil
+}
+
+// captureLogger returns a logger that writes JSON lines into a buffer plus
+// the buffer itself for assertions.
+func captureLogger(t *testing.T) (*slog.Logger, *bytes.Buffer) {
+	t.Helper()
+	var buf bytes.Buffer
+	return slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})), &buf
+}
+
+func TestChain_RejectsWithoutTokenWhenAnonymousOff(t *testing.T) {
+	c := NewChain(false, nil, nil)
+	_, err := c.Authenticate(context.Background())
+	if !errors.Is(err, ErrNotAuthenticated) {
+		t.Errorf("err = %v, want ErrNotAuthenticated", err)
+	}
+}
+
+func TestChain_OIDCFirstHeuristic(t *testing.T) {
+	oidc := &fakeOIDC{} // succeeds
+	keys := &fakeAPIKeys{err: errors.New("should not be hit")}
+	c := NewChain(false, keys, oidc)
+
+	// JWT-shaped token (starts with "ey") tries OIDC first, gets identity,
+	// never falls through to API keys.
+	ctx := WithToken(context.Background(), "eyJhbGciOiJSUzI1NiJ9.foo.bar")
+	id, err := c.Authenticate(ctx)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if id.AuthType != "oidc" {
+		t.Errorf("AuthType = %q, want oidc", id.AuthType)
+	}
+}
+
+func TestChain_NonJWTTriesAPIKeyFirst(t *testing.T) {
+	oidc := &fakeOIDC{err: errors.New("should not be hit")}
+	keys := &fakeAPIKeys{} // succeeds
+	c := NewChain(false, keys, oidc)
+
+	ctx := WithToken(context.Background(), "mcptest_plain_key")
+	id, err := c.Authenticate(ctx)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if id.AuthType != "apikey" {
+		t.Errorf("AuthType = %q, want apikey", id.AuthType)
+	}
+}
+
+func TestChain_LogsOIDCRejectionWithMethodTag(t *testing.T) {
+	logger, buf := captureLogger(t)
+	c := NewChain(false, nil, &fakeOIDC{err: errors.New("audience mismatch: want \"prod\"")}).WithLogger(logger)
+
+	ctx := WithToken(context.Background(), "eyJ.bad.jwt")
+	_, err := c.Authenticate(ctx)
+	if !errors.Is(err, ErrNotAuthenticated) {
+		t.Fatalf("err = %v, want ErrNotAuthenticated", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `"level":"WARN"`) {
+		t.Errorf("expected WARN level, got: %s", out)
+	}
+	if !strings.Contains(out, `"method":"oidc"`) {
+		t.Errorf("expected method=oidc tag, got: %s", out)
+	}
+	if !strings.Contains(out, "audience mismatch") {
+		t.Errorf("expected error detail in log, got: %s", out)
+	}
+	// The token must NEVER be logged.
+	if strings.Contains(out, "eyJ.bad.jwt") {
+		t.Errorf("token leaked into log: %s", out)
+	}
+}
+
+func TestChain_LogsAPIKeyRejection(t *testing.T) {
+	logger, buf := captureLogger(t)
+	c := NewChain(false, &fakeAPIKeys{err: errors.New("unknown api key")}, nil).WithLogger(logger)
+
+	ctx := WithToken(context.Background(), "mcptest_unknown_key_value")
+	_, _ = c.Authenticate(ctx)
+	out := buf.String()
+	if !strings.Contains(out, `"method":"apikey"`) {
+		t.Errorf("expected method=apikey tag, got: %s", out)
+	}
+	if !strings.Contains(out, "unknown api key") {
+		t.Errorf("expected error detail, got: %s", out)
+	}
+	if strings.Contains(out, "mcptest_unknown_key_value") {
+		t.Errorf("token leaked into log: %s", out)
+	}
+}
+
+func TestChain_LogsBothPathsOnFullChainMiss(t *testing.T) {
+	// Non-JWT token: tries apikey first, falls through to oidc. Both should
+	// log independently when both reject.
+	logger, buf := captureLogger(t)
+	c := NewChain(false,
+		&fakeAPIKeys{err: errors.New("no key match")},
+		&fakeOIDC{err: errors.New("not a jwt")},
+	).WithLogger(logger)
+
+	ctx := WithToken(context.Background(), "plain-token")
+	_, err := c.Authenticate(ctx)
+	if !errors.Is(err, ErrNotAuthenticated) {
+		t.Fatalf("err = %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `"method":"apikey"`) {
+		t.Errorf("missing apikey log: %s", out)
+	}
+	if !strings.Contains(out, `"method":"oidc"`) {
+		t.Errorf("missing oidc log: %s", out)
+	}
+	if !strings.Contains(out, "no key match") || !strings.Contains(out, "not a jwt") {
+		t.Errorf("missing per-method error detail: %s", out)
+	}
+}
+
+func TestChain_NoLogsOnSuccess(t *testing.T) {
+	logger, buf := captureLogger(t)
+	c := NewChain(false, &fakeAPIKeys{}, nil).WithLogger(logger)
+
+	ctx := WithToken(context.Background(), "good-key")
+	_, err := c.Authenticate(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected no log output on success, got: %s", buf.String())
+	}
+}
+
+func TestChain_NoLogsOnEmptyToken(t *testing.T) {
+	// Missing-token path returns ErrNotAuthenticated directly without
+	// invoking any authenticator; no log should be written.
+	logger, buf := captureLogger(t)
+	c := NewChain(false, &fakeAPIKeys{err: errors.New("x")}, &fakeOIDC{err: errors.New("y")}).WithLogger(logger)
+
+	_, _ = c.Authenticate(context.Background())
+	if buf.Len() != 0 {
+		t.Errorf("expected no log output on empty-token path, got: %s", buf.String())
+	}
+}
+
+func TestChain_WithLogger_NilFallsBackToDefault(t *testing.T) {
+	c := NewChain(false, nil, nil).WithLogger(nil)
+	if c.logger == nil {
+		t.Error("WithLogger(nil) should fall back to slog.Default(), not leave nil")
+	}
+}
+
+func TestChain_DefaultLoggerSet(t *testing.T) {
+	c := NewChain(false, nil, nil)
+	if c.logger == nil {
+		t.Error("NewChain should set logger to slog.Default()")
+	}
+}

--- a/pkg/auth/chain_test.go
+++ b/pkg/auth/chain_test.go
@@ -7,12 +7,21 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 )
 
-// fakeOIDC always returns the configured error from ValidateBearer.
-type fakeOIDC struct{ err error }
+// fakeOIDC always returns the configured error from ValidateBearer. The
+// errFn variant lets a test produce a token-dependent error so we can
+// verify the chain's redaction.
+type fakeOIDC struct {
+	err   error
+	errFn func(token string) error
+}
 
-func (f *fakeOIDC) ValidateBearer(_ context.Context, _ string) (*Identity, error) {
+func (f *fakeOIDC) ValidateBearer(_ context.Context, tok string) (*Identity, error) {
+	if f.errFn != nil {
+		return nil, f.errFn(tok)
+	}
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -20,9 +29,15 @@ func (f *fakeOIDC) ValidateBearer(_ context.Context, _ string) (*Identity, error
 }
 
 // fakeAPIKeys returns the configured error from Authenticate.
-type fakeAPIKeys struct{ err error }
+type fakeAPIKeys struct {
+	err   error
+	errFn func(token string) error
+}
 
-func (f *fakeAPIKeys) Authenticate(_ context.Context, _ string) (*Identity, error) {
+func (f *fakeAPIKeys) Authenticate(_ context.Context, tok string) (*Identity, error) {
+	if f.errFn != nil {
+		return nil, f.errFn(tok)
+	}
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -50,8 +65,6 @@ func TestChain_OIDCFirstHeuristic(t *testing.T) {
 	keys := &fakeAPIKeys{err: errors.New("should not be hit")}
 	c := NewChain(false, keys, oidc)
 
-	// JWT-shaped token (starts with "ey") tries OIDC first, gets identity,
-	// never falls through to API keys.
 	ctx := WithToken(context.Background(), "eyJhbGciOiJSUzI1NiJ9.foo.bar")
 	id, err := c.Authenticate(ctx)
 	if err != nil {
@@ -77,59 +90,85 @@ func TestChain_NonJWTTriesAPIKeyFirst(t *testing.T) {
 	}
 }
 
-func TestChain_LogsOIDCRejectionWithMethodTag(t *testing.T) {
+func TestChain_LogsOIDCRejectionWithMethodAndCorrelation(t *testing.T) {
 	logger, buf := captureLogger(t)
-	c := NewChain(false, nil, &fakeOIDC{err: errors.New("audience mismatch: want \"prod\"")}).WithLogger(logger)
+	c := NewChain(false, nil, &fakeOIDC{err: errors.New("audience mismatch: want \"prod\"")}).SetLogger(logger)
 
 	ctx := WithToken(context.Background(), "eyJ.bad.jwt")
+	ctx = WithRequestID(ctx, "req-abc-123")
+	ctx = WithRemoteAddr(ctx, "10.0.0.7")
 	_, err := c.Authenticate(ctx)
 	if !errors.Is(err, ErrNotAuthenticated) {
 		t.Fatalf("err = %v, want ErrNotAuthenticated", err)
 	}
 	out := buf.String()
 	if !strings.Contains(out, `"level":"WARN"`) {
-		t.Errorf("expected WARN level, got: %s", out)
+		t.Errorf("expected WARN (first failure), got: %s", out)
 	}
 	if !strings.Contains(out, `"method":"oidc"`) {
-		t.Errorf("expected method=oidc tag, got: %s", out)
+		t.Errorf("expected method=oidc, got: %s", out)
+	}
+	if !strings.Contains(out, `"request_id":"req-abc-123"`) {
+		t.Errorf("expected request_id field, got: %s", out)
+	}
+	if !strings.Contains(out, `"remote_addr":"10.0.0.7"`) {
+		t.Errorf("expected remote_addr field, got: %s", out)
 	}
 	if !strings.Contains(out, "audience mismatch") {
-		t.Errorf("expected error detail in log, got: %s", out)
+		t.Errorf("expected error detail, got: %s", out)
 	}
-	// The token must NEVER be logged.
-	if strings.Contains(out, "eyJ.bad.jwt") {
-		t.Errorf("token leaked into log: %s", out)
+}
+
+func TestChain_RedactsJWTInValidatorError(t *testing.T) {
+	// Verify the chain itself strips JWT-shape substrings even when the
+	// validator unwisely embeds the rejected token in its error. This
+	// tests the redaction code, not the fake's discipline.
+	logger, buf := captureLogger(t)
+	jwt := "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhbGljZSJ9.deadbeefcafebabe1234567890"
+	leakyOIDC := &fakeOIDC{errFn: func(token string) error {
+		return errors.New("rejected token: " + token)
+	}}
+	c := NewChain(false, nil, leakyOIDC).SetLogger(logger)
+
+	ctx := WithToken(context.Background(), jwt)
+	_, _ = c.Authenticate(ctx)
+	out := buf.String()
+	if strings.Contains(out, jwt) {
+		t.Errorf("JWT leaked into log despite redaction:\n%s", out)
+	}
+	if !strings.Contains(out, "[redacted-jwt]") {
+		t.Errorf("expected [redacted-jwt] marker in log, got: %s", out)
+	}
+	// And the surrounding error message should still be useful.
+	if !strings.Contains(out, "rejected token") {
+		t.Errorf("expected error context preserved around redaction, got: %s", out)
 	}
 }
 
 func TestChain_LogsAPIKeyRejection(t *testing.T) {
 	logger, buf := captureLogger(t)
-	c := NewChain(false, &fakeAPIKeys{err: errors.New("unknown api key")}, nil).WithLogger(logger)
+	c := NewChain(false, &fakeAPIKeys{err: errors.New("unknown api key")}, nil).SetLogger(logger)
 
-	ctx := WithToken(context.Background(), "mcptest_unknown_key_value")
+	ctx := WithToken(context.Background(), "mcptest_unknown_key")
 	_, _ = c.Authenticate(ctx)
 	out := buf.String()
 	if !strings.Contains(out, `"method":"apikey"`) {
-		t.Errorf("expected method=apikey tag, got: %s", out)
+		t.Errorf("expected method=apikey, got: %s", out)
 	}
 	if !strings.Contains(out, "unknown api key") {
 		t.Errorf("expected error detail, got: %s", out)
 	}
-	if strings.Contains(out, "mcptest_unknown_key_value") {
-		t.Errorf("token leaked into log: %s", out)
-	}
 }
 
 func TestChain_LogsBothPathsOnFullChainMiss(t *testing.T) {
-	// Non-JWT token: tries apikey first, falls through to oidc. Both should
-	// log independently when both reject.
 	logger, buf := captureLogger(t)
 	c := NewChain(false,
 		&fakeAPIKeys{err: errors.New("no key match")},
 		&fakeOIDC{err: errors.New("not a jwt")},
-	).WithLogger(logger)
+	).SetLogger(logger)
 
 	ctx := WithToken(context.Background(), "plain-token")
+	ctx = WithRemoteAddr(ctx, "10.0.0.8")
 	_, err := c.Authenticate(ctx)
 	if !errors.Is(err, ErrNotAuthenticated) {
 		t.Fatalf("err = %v", err)
@@ -141,14 +180,21 @@ func TestChain_LogsBothPathsOnFullChainMiss(t *testing.T) {
 	if !strings.Contains(out, `"method":"oidc"`) {
 		t.Errorf("missing oidc log: %s", out)
 	}
-	if !strings.Contains(out, "no key match") || !strings.Contains(out, "not a jwt") {
-		t.Errorf("missing per-method error detail: %s", out)
+	// First entry per remote_addr in window is WARN; the second
+	// (different method, same source within the same call) is DEBUG.
+	warnCount := strings.Count(out, `"level":"WARN"`)
+	debugCount := strings.Count(out, `"level":"DEBUG"`)
+	if warnCount != 1 {
+		t.Errorf("expected 1 WARN line (rate-limited), got %d:\n%s", warnCount, out)
+	}
+	if debugCount != 1 {
+		t.Errorf("expected 1 DEBUG line, got %d:\n%s", debugCount, out)
 	}
 }
 
 func TestChain_NoLogsOnSuccess(t *testing.T) {
 	logger, buf := captureLogger(t)
-	c := NewChain(false, &fakeAPIKeys{}, nil).WithLogger(logger)
+	c := NewChain(false, &fakeAPIKeys{}, nil).SetLogger(logger)
 
 	ctx := WithToken(context.Background(), "good-key")
 	_, err := c.Authenticate(ctx)
@@ -161,10 +207,8 @@ func TestChain_NoLogsOnSuccess(t *testing.T) {
 }
 
 func TestChain_NoLogsOnEmptyToken(t *testing.T) {
-	// Missing-token path returns ErrNotAuthenticated directly without
-	// invoking any authenticator; no log should be written.
 	logger, buf := captureLogger(t)
-	c := NewChain(false, &fakeAPIKeys{err: errors.New("x")}, &fakeOIDC{err: errors.New("y")}).WithLogger(logger)
+	c := NewChain(false, &fakeAPIKeys{err: errors.New("x")}, &fakeOIDC{err: errors.New("y")}).SetLogger(logger)
 
 	_, _ = c.Authenticate(context.Background())
 	if buf.Len() != 0 {
@@ -172,10 +216,40 @@ func TestChain_NoLogsOnEmptyToken(t *testing.T) {
 	}
 }
 
-func TestChain_WithLogger_NilFallsBackToDefault(t *testing.T) {
-	c := NewChain(false, nil, nil).WithLogger(nil)
+func TestChain_NoStoresConfigured_TokenPresent(t *testing.T) {
+	// Both stores nil + token present + anonymous off: nothing to try,
+	// chain returns ErrNotAuthenticated and emits nothing.
+	logger, buf := captureLogger(t)
+	c := NewChain(false, nil, nil).SetLogger(logger)
+	ctx := WithToken(context.Background(), "anything")
+	_, err := c.Authenticate(ctx)
+	if !errors.Is(err, ErrNotAuthenticated) {
+		t.Errorf("err = %v, want ErrNotAuthenticated", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected no log output when no stores configured, got: %s", buf.String())
+	}
+}
+
+func TestChain_AnonymousOnEmptyTokenStillReturnsAnonymous(t *testing.T) {
+	logger, buf := captureLogger(t)
+	c := NewChain(true, nil, nil).SetLogger(logger)
+	id, err := c.Authenticate(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id.AuthType != "anonymous" {
+		t.Errorf("AuthType = %q, want anonymous", id.AuthType)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("anonymous-allowed empty-token path should not log, got: %s", buf.String())
+	}
+}
+
+func TestChain_SetLogger_NilFallsBackToDefault(t *testing.T) {
+	c := NewChain(false, nil, nil).SetLogger(nil)
 	if c.logger == nil {
-		t.Error("WithLogger(nil) should fall back to slog.Default(), not leave nil")
+		t.Error("SetLogger(nil) should fall back to slog.Default()")
 	}
 }
 
@@ -183,5 +257,122 @@ func TestChain_DefaultLoggerSet(t *testing.T) {
 	c := NewChain(false, nil, nil)
 	if c.logger == nil {
 		t.Error("NewChain should set logger to slog.Default()")
+	}
+	if c.rateLimit == nil {
+		t.Error("NewChain should set rateLimit")
+	}
+}
+
+func TestChain_WithLogger_DeprecatedAlias(t *testing.T) {
+	// WithLogger remains as an alias for SetLogger; verify it still works.
+	logger, _ := captureLogger(t)
+	c := NewChain(false, nil, nil).WithLogger(logger)
+	if c.logger != logger {
+		t.Error("WithLogger should set the logger")
+	}
+}
+
+// --- redactTokenLikes ---
+
+func TestRedactTokenLikes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string // empty means must not appear in output
+	}{
+		{
+			name: "classic three-segment JWT",
+			in:   "rejected: eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhbGljZSJ9.signature_bytes_here",
+			want: "rejected: [redacted-jwt]",
+		},
+		{
+			name: "no JWT means no change",
+			in:   "audience mismatch: want \"prod\"",
+			want: "audience mismatch: want \"prod\"",
+		},
+		{
+			name: "short dotted identifier (not JWT-shaped) passes through",
+			in:   "lookup failed for a.b.c",
+			want: "lookup failed for a.b.c",
+		},
+		{
+			name: "JWT mid-sentence",
+			in:   "the token eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhbGljZSJ9.deadbeefcafebabe was rejected",
+			want: "the token [redacted-jwt] was rejected",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := redactTokenLikes(c.in)
+			if got != c.want {
+				t.Errorf("redactTokenLikes\n in:   %q\n got:  %q\n want: %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// --- failureRateLimiter ---
+
+func TestFailureRateLimiter_FirstWarnsThenDemotes(t *testing.T) {
+	r := newFailureRateLimiter(50 * time.Millisecond)
+	if !r.shouldWarn("10.0.0.1") {
+		t.Error("first call should warn")
+	}
+	if r.shouldWarn("10.0.0.1") {
+		t.Error("second call within window should not warn")
+	}
+	// Different key starts its own window.
+	if !r.shouldWarn("10.0.0.2") {
+		t.Error("different key first call should warn")
+	}
+	// After the window elapses, the original key warns again.
+	time.Sleep(60 * time.Millisecond)
+	if !r.shouldWarn("10.0.0.1") {
+		t.Error("after window elapsed, key should warn again")
+	}
+}
+
+func TestFailureRateLimiter_EmptyKeyAlwaysWarns(t *testing.T) {
+	// No remote_addr → no key to bucket on. Every call returns true so
+	// the operator still sees the failure on the first instance per
+	// request (and there's only one per request).
+	r := newFailureRateLimiter(time.Minute)
+	if !r.shouldWarn("") {
+		t.Error("empty key should warn")
+	}
+	if !r.shouldWarn("") {
+		t.Error("empty key should always warn (no bucketing)")
+	}
+}
+
+func TestFailureRateLimiter_NilSafe(t *testing.T) {
+	var r *failureRateLimiter
+	if !r.shouldWarn("anything") {
+		t.Error("nil receiver should default to warn-allowed")
+	}
+}
+
+func TestFailureRateLimiter_DefaultWindow(t *testing.T) {
+	// Window <= 0 should fall back to a minute, not loop forever.
+	r := newFailureRateLimiter(0)
+	if r.window != time.Minute {
+		t.Errorf("default window = %v, want 1m", r.window)
+	}
+}
+
+func TestFailureRateLimiter_EvictsStaleEntries(t *testing.T) {
+	r := newFailureRateLimiter(20 * time.Millisecond)
+	for i := 0; i < 10; i++ {
+		r.shouldWarn("client-" + string(rune('0'+i)))
+	}
+	if len(r.lastLog) != 10 {
+		t.Fatalf("expected 10 entries, got %d", len(r.lastLog))
+	}
+	time.Sleep(30 * time.Millisecond)
+	// Trigger eviction by issuing one new call.
+	r.shouldWarn("trigger")
+	if len(r.lastLog) > 1 {
+		// Only the trigger key (or a new check) should remain post-eviction.
+		t.Errorf("expected stale eviction, got %d entries", len(r.lastLog))
 	}
 }

--- a/pkg/httpsrv/authgate.go
+++ b/pkg/httpsrv/authgate.go
@@ -11,6 +11,16 @@ import (
 // with a WWW-Authenticate header that points MCP clients at the
 // /.well-known/oauth-protected-resource document.
 //
+// The WWW-Authenticate challenge follows RFC 6750 §3:
+//
+//	Bearer realm="mcp-test", error="invalid_request",
+//	  error_description="missing or unsupported credential",
+//	  resource_metadata="<url>"
+//
+// MCP clients that follow the spec surface error / error_description to
+// the user, so the rejection has a useful diagnostic instead of an
+// opaque 401.
+//
 // Validation of the token (signature, audience, key lookup) is intentionally
 // deferred to the MCP-side audit middleware so that failed-auth attempts also
 // produce audit rows.
@@ -27,16 +37,44 @@ func MCPAuthGateway(resourceMetadataURL string, allowAnonymous bool) func(http.H
 				next.ServeHTTP(w, r)
 				return
 			}
-			challenge := `Bearer realm="mcp-test"`
-			if resourceMetadataURL != "" {
-				challenge += `, resource_metadata="` + resourceMetadataURL + `"`
-			}
-			w.Header().Set("WWW-Authenticate", challenge)
+			w.Header().Set("WWW-Authenticate", buildBearerChallenge(resourceMetadataURL,
+				"invalid_request",
+				"missing or unsupported credential; supply X-API-Key or Authorization: Bearer <token>",
+			))
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusUnauthorized)
-			_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+			_, _ = w.Write([]byte(`{"error":"unauthorized","error_description":"missing or unsupported credential"}`))
 		})
 	}
+}
+
+// buildBearerChallenge composes an RFC 6750 §3 Bearer challenge. error
+// and errorDescription are optional; pass empty strings to omit them.
+// Quote-escaping follows the auth-param ABNF (RFC 7235 §2.1): backslash
+// and double-quote are escaped; other characters pass through. The
+// validators we use construct error_description strings without those
+// metacharacters, so escaping is belt-and-suspenders rather than a
+// real defense.
+func buildBearerChallenge(resourceMetadataURL, errCode, errDescription string) string {
+	parts := []string{`Bearer realm="mcp-test"`}
+	if errCode != "" {
+		parts = append(parts, `error="`+quoteAuthParam(errCode)+`"`)
+	}
+	if errDescription != "" {
+		parts = append(parts, `error_description="`+quoteAuthParam(errDescription)+`"`)
+	}
+	if resourceMetadataURL != "" {
+		parts = append(parts, `resource_metadata="`+quoteAuthParam(resourceMetadataURL)+`"`)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func quoteAuthParam(s string) string {
+	if !strings.ContainsAny(s, `\"`) {
+		return s
+	}
+	r := strings.NewReplacer(`\`, `\\`, `"`, `\"`)
+	return r.Replace(s)
 }
 
 func hasCredential(r *http.Request) bool {

--- a/pkg/httpsrv/authgate_test.go
+++ b/pkg/httpsrv/authgate_test.go
@@ -72,3 +72,64 @@ func TestMCPAuthGateway_BasicAuthRejected(t *testing.T) {
 		t.Errorf("status = %d", w.Code)
 	}
 }
+
+func TestMCPAuthGateway_RFC6750ChallengeFields(t *testing.T) {
+	// RFC 6750 §3 says a bearer challenge SHOULD include error and
+	// error_description when the request is rejected; clients use those
+	// to surface a useful diagnostic instead of an opaque 401.
+	gate := MCPAuthGateway("https://example/rm", false)
+	h := gate(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	got := w.Header().Get("WWW-Authenticate")
+	wantSubstrings := []string{
+		`Bearer realm="mcp-test"`,
+		`error="invalid_request"`,
+		`error_description="missing or unsupported credential`,
+		`resource_metadata="https://example/rm"`,
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(got, want) {
+			t.Errorf("WWW-Authenticate missing %q\n got: %s", want, got)
+		}
+	}
+
+	// Body also carries error_description so non-RFC-aware clients see it.
+	body := w.Body.String()
+	if !strings.Contains(body, `"error_description"`) {
+		t.Errorf("body missing error_description: %s", body)
+	}
+}
+
+func TestBuildBearerChallenge_OmitsBlankFields(t *testing.T) {
+	// Both error fields blank: only realm and resource_metadata appear.
+	got := buildBearerChallenge("https://x/rm", "", "")
+	if strings.Contains(got, "error=") || strings.Contains(got, "error_description=") {
+		t.Errorf("blank err fields should be omitted: %s", got)
+	}
+	if !strings.Contains(got, `resource_metadata="https://x/rm"`) {
+		t.Errorf("expected resource_metadata: %s", got)
+	}
+
+	// No metadata URL either: minimal challenge.
+	got = buildBearerChallenge("", "", "")
+	if got != `Bearer realm="mcp-test"` {
+		t.Errorf("minimal challenge = %q", got)
+	}
+}
+
+func TestQuoteAuthParam_EscapesQuotesAndBackslashes(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"plain", "plain"},
+		{`with "quotes"`, `with \"quotes\"`},
+		{`back\slash`, `back\\slash`},
+		{`both \"`, `both \\\"`},
+	}
+	for _, c := range cases {
+		if got := quoteAuthParam(c.in); got != c.want {
+			t.Errorf("quoteAuthParam(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #2.

## Summary

`Chain.Authenticate` was dropping every error from `OIDCValidator.ValidateBearer` and `APIKeyStore.Authenticate`, falling through to the next method or to `ErrNotAuthenticated`. When OIDC rejected a bearer for any reason (audience mismatch, JWKS miss, expired-with-clock-skew, signature failure), the calling client got a `401` with no body, no log, no diagnostic surface.

This PR makes the chain log every per-authenticator rejection, attaches request correlation, redacts JWT-shape token bytes, rate-limits per remote_addr, and has `MCPAuthGateway` emit a proper RFC 6750 §3 `WWW-Authenticate` challenge so MCP clients see a useful diagnostic alongside the 401.

## Changes

### `pkg/auth/chain.go`

- `Chain` owns a `*slog.Logger` (defaults to `slog.Default()`, overridable via `SetLogger`). `WithLogger` is kept as a deprecated alias so existing callers don't break.
- Every rejection from a configured authenticator gets one log line tagged `method=oidc|apikey` plus the underlying error and request correlation fields (`request_id`, `remote_addr`) pulled from ctx.
- **Token redaction:** `redactTokenLikes` strips JWT-shape substrings (`xxx.yyy.zzz` of base64url segments ≥8 chars) from the validator's error string before logging. Defense-in-depth on top of "validators don't echo tokens"; we now actually enforce it at the chain layer rather than just trusting downstream.
- **Rate-limited WARN:** first failure per `remote_addr` per 60s window logs at WARN; subsequent failures in the window log at DEBUG. Without this, a scanner hitting 401s at line speed would flood operator logs and crowd out real signal. Empty `remote_addr` (no correlation context available) bypasses the bucket so single-shot failures still surface at WARN.
- Public API stays backward-compatible: `NewChain(allowAnonymous, apiKeys, oidc)` is unchanged.

### `pkg/httpsrv/authgate.go`

- `MCPAuthGateway`'s 401 response now follows RFC 6750 §3:
  ```
  WWW-Authenticate: Bearer realm="mcp-test",
    error="invalid_request",
    error_description="missing or unsupported credential; supply X-API-Key or Authorization: Bearer <token>",
    resource_metadata="<url>"
  ```
  MCP clients that follow the spec surface `error` / `error_description` to the user. The JSON body now includes `error_description` too, for non-RFC-aware clients.
- `buildBearerChallenge` composes the challenge with proper RFC 7235 §2.1 quote escaping (`"` and `\` are escaped per the auth-param ABNF).

### `internal/server/server.go`

- Wires the application's logger into the chain via `NewChain(...).SetLogger(logger)` so log lines come out under the same JSON handler as the rest of the binary.

## New tests

**`pkg/auth/chain_test.go`** covers:
- Empty token (no log, `ErrNotAuthenticated`).
- Anonymous-on + empty token (no log, anonymous identity).
- Both stores nil + token present (no log, `ErrNotAuthenticated`).
- Successful auth (no log).
- JWT-shaped token tries OIDC first; non-JWT tries apikey first.
- OIDC rejection with `request_id` + `remote_addr` correlation in the log line.
- API key rejection log shape.
- Full-chain miss: rate limiter demotes the second log line in the same window from WARN to DEBUG.
- **Real redaction test:** a leaky validator that embeds the token in its error is constructed; the chain redacts it. The previous version of this test only verified the fake's discipline.
- `redactTokenLikes` table covering classic three-segment JWT, no-JWT, mid-sentence JWT, short non-JWT dotted identifiers.
- `failureRateLimiter`: first warns then demotes within window, different keys are independent, window elapse re-warns, empty key never bucketed, nil-receiver safe, default-window fallback, stale-entry eviction.
- `SetLogger(nil)` falls back to `slog.Default()`; `NewChain` sets the logger and rate limiter.
- `WithLogger` deprecated alias still works.

**`pkg/httpsrv/authgate_test.go`** adds:
- RFC 6750 §3 challenge fields all present (`realm`, `error`, `error_description`, `resource_metadata`).
- `error_description` mirrored into the JSON body.
- `buildBearerChallenge` omits blank fields.
- `quoteAuthParam` escapes `"` and `\` per auth-param ABNF.

## Sample log output

For an OIDC token rejected on audience mismatch (first failure from `10.0.0.7`):

```json
{"time":"2026-04-30T07:42:18Z","level":"WARN","msg":"auth: token rejected","method":"oidc","error":"audience mismatch: want \"prod\"","request_id":"req-abc-123","remote_addr":"10.0.0.7"}
```

A second failure from the same source within 60s gets demoted to DEBUG; identical content otherwise.

For a leaky validator that included the rejected JWT in its error:

```json
{"time":"...","level":"WARN","msg":"auth: token rejected","method":"oidc","error":"rejected token: [redacted-jwt]","request_id":"...","remote_addr":"..."}
```

## Test plan

- [x] `make verify` passes (lint + race-tested test suite + 80% coverage gate).
- [x] All review findings from the PR review are addressed in code: redaction, rate limiting, correlation fields, real redaction test, dead-code nil-check removed, `slog.LogAttrs` with typed string attrs, `SetLogger` rename with deprecated alias, both-stores-nil test added.
- [ ] On a deployment with OIDC enabled, hit any endpoint with a wrong-audience token; confirm one WARN line per remote_addr per minute with `method=oidc`, the audience-mismatch error, and the `request_id` matching the audit_events row. Subsequent failures from the same source in the same minute appear at DEBUG.
- [ ] On the same deployment, hit any endpoint with no credential; confirm the 401 carries `WWW-Authenticate: Bearer realm="mcp-test", error="invalid_request", error_description="...", resource_metadata="..."` and the JSON body has `error_description`.