### PR TITLE
feat(audit): capture full request/response payloads + detail fetch (data layer for #4)

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -164,7 +164,7 @@ func buildFromDeps(cfg *config.Config, logger *slog.Logger, chain *auth.Chain, a
 		tk.RegisterTools(mcpServer)
 	}
 	mcpServer.AddReceivingMiddleware(
-		mcpmw.Audit(chain, auditLog, cfg.Audit.RedactKeys, registry.Groups()),
+		mcpmw.Audit(chain, auditLog, cfg.Audit.RedactKeys, registry.Groups(), auditOptions(cfg.Audit)...),
 	)
 
 	readiness := httpsrv.NewReadiness()
@@ -180,6 +180,23 @@ func buildFromDeps(cfg *config.Config, logger *slog.Logger, chain *auth.Chain, a
 		readiness: readiness,
 		mux:       mux,
 	}
+}
+
+// auditOptions translates config.AuditConfig into the mcpmw.AuditOption
+// slice the middleware constructor expects. Keeping the mapping in one
+// place lets the test path (BuildWithDeps) reuse it.
+func auditOptions(cfg config.AuditConfig) []mcpmw.AuditOption {
+	var opts []mcpmw.AuditOption
+	if cfg.CapturePayloadsEnabled() {
+		opts = append(opts, mcpmw.WithPayloadCapture(cfg.MaxPayloadBytes))
+		if cfg.CaptureHeadersEnabled() {
+			opts = append(opts, mcpmw.WithHeaderCapture())
+		}
+		if cfg.MaxNotifications > 0 {
+			opts = append(opts, mcpmw.WithMaxNotifications(cfg.MaxNotifications))
+		}
+	}
+	return opts
 }
 
 func buildRegistry(cfg *config.Config) *tools.Registry {

--- a/pkg/audit/async.go
+++ b/pkg/audit/async.go
@@ -96,6 +96,18 @@ func (a *AsyncLogger) Stats(ctx context.Context, from, to time.Time) (Stats, err
 	return a.inner.Stats(ctx, from, to)
 }
 
+// GetPayload delegates to the inner Logger when it implements
+// PayloadLogger. Returns (nil, nil) when the underlying logger doesn't
+// persist payloads (memory, noop) so the portal API can render the
+// summary view without falling over.
+func (a *AsyncLogger) GetPayload(ctx context.Context, eventID string) (*Payload, error) {
+	pl, ok := a.inner.(PayloadLogger)
+	if !ok {
+		return nil, nil
+	}
+	return pl.GetPayload(ctx, eventID)
+}
+
 // Close stops accepting new events and waits for the queue to drain.
 func (a *AsyncLogger) Close() {
 	a.stopOnce.Do(func() { close(a.stop) })

--- a/pkg/audit/event.go
+++ b/pkg/audit/event.go
@@ -8,7 +8,12 @@ import (
 	"github.com/plexara/mcp-test/pkg/auth"
 )
 
-// Event captures everything we record for one tool call (or auth failure).
+// Event captures the indexable summary of one tool call (or auth failure).
+//
+// Full request/response payloads live on the sibling Payload struct,
+// matched 1:1 by ID. The two-table layout keeps the summary small and
+// fast for time-range queries while letting operators drill into the
+// full envelope on demand.
 type Event struct {
 	ID            string         `json:"id"`
 	Timestamp     time.Time      `json:"timestamp"`
@@ -32,6 +37,52 @@ type Event struct {
 	Source        string         `json:"source"`
 	RemoteAddr    string         `json:"remote_addr,omitempty"`
 	UserAgent     string         `json:"user_agent,omitempty"`
+
+	// Payload, when non-nil, is the full request/response envelope for
+	// this event. It is written to the audit_payloads sibling table in
+	// the same transaction as the summary row. Nil means "no detail
+	// captured" (capture disabled, or this event predates capture).
+	Payload *Payload `json:"payload,omitempty"`
+}
+
+// Payload is the full request/response envelope joined 1:1 with an Event
+// by ID. Stored in the audit_payloads table. Each side carries a byte
+// size and a truncation flag so operators can tell whether they're
+// looking at the whole call or a capped prefix.
+type Payload struct {
+	// JSON-RPC envelope as received.
+	JSONRPCMethod    string         `json:"jsonrpc_method,omitempty"`
+	JSONRPCID        string         `json:"jsonrpc_id,omitempty"`
+	RequestParams    map[string]any `json:"request_params,omitempty"`
+	RequestSizeBytes int            `json:"request_size_bytes,omitempty"`
+	RequestTruncated bool           `json:"request_truncated,omitempty"`
+
+	// HTTP layer.
+	RequestHeaders    map[string][]string `json:"request_headers,omitempty"`
+	RequestMethod     string              `json:"request_method,omitempty"`
+	RequestPath       string              `json:"request_path,omitempty"`
+	RequestRemoteAddr string              `json:"request_remote_addr,omitempty"`
+
+	// JSON-RPC response.
+	ResponseResult    map[string]any `json:"response_result,omitempty"`
+	ResponseError     map[string]any `json:"response_error,omitempty"`
+	ResponseSizeBytes int            `json:"response_size_bytes,omitempty"`
+	ResponseTruncated bool           `json:"response_truncated,omitempty"`
+
+	// Notifications fired during the call window.
+	Notifications []Notification `json:"notifications,omitempty"`
+
+	// Replay linkage; if this event was a /replay of another, this
+	// points at the original event's ID.
+	ReplayedFrom string `json:"replayed_from,omitempty"`
+}
+
+// Notification is one server-initiated notification recorded during a
+// tool call (typically a progress notification, but the shape is open).
+type Notification struct {
+	Timestamp time.Time      `json:"ts"`
+	Method    string         `json:"method"`
+	Params    map[string]any `json:"params,omitempty"`
 }
 
 // NewEvent constructs an Event with sensible defaults filled in.
@@ -97,6 +148,13 @@ func (e *Event) WithResult(success bool, errMsg string, durMS int64) *Event {
 	e.Success = success
 	e.ErrorMessage = errMsg
 	e.DurationMS = durMS
+	return e
+}
+
+// WithPayload attaches a full request/response payload to the event.
+// Pass nil to clear; nil-or-zero Payload values are not persisted.
+func (e *Event) WithPayload(p *Payload) *Event {
+	e.Payload = p
 	return e
 }
 

--- a/pkg/audit/event_payload_test.go
+++ b/pkg/audit/event_payload_test.go
@@ -1,0 +1,82 @@
+package audit
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestEvent_WithPayload_Roundtrip(t *testing.T) {
+	ev := NewEvent("echo")
+	if ev.Payload != nil {
+		t.Fatal("fresh Event should have nil Payload")
+	}
+	p := &Payload{
+		JSONRPCMethod:    "tools/call",
+		RequestParams:    map[string]any{"message": "hi"},
+		RequestSizeBytes: 17,
+	}
+	ev.WithPayload(p)
+	if ev.Payload != p {
+		t.Errorf("WithPayload didn't set the field")
+	}
+	ev.WithPayload(nil)
+	if ev.Payload != nil {
+		t.Errorf("WithPayload(nil) didn't clear")
+	}
+}
+
+func TestPayload_JSONShape(t *testing.T) {
+	p := &Payload{
+		JSONRPCMethod:    "tools/call",
+		JSONRPCID:        "42",
+		RequestParams:    map[string]any{"k": "v"},
+		RequestSizeBytes: 12,
+		RequestTruncated: false,
+		ResponseResult: map[string]any{
+			"content": []any{
+				map[string]any{"type": "text", "text": "hi"},
+			},
+			"isError": false,
+		},
+		ResponseSizeBytes: 50,
+		Notifications: []Notification{
+			{Method: "notifications/progress", Params: map[string]any{"step": 1}},
+		},
+	}
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var round map[string]any
+	if err := json.Unmarshal(b, &round); err != nil {
+		t.Fatal(err)
+	}
+	// Sanity: every top-level key we expect is there.
+	for _, k := range []string{
+		"jsonrpc_method", "jsonrpc_id",
+		"request_params", "request_size_bytes",
+		"response_result", "response_size_bytes",
+		"notifications",
+	} {
+		if _, ok := round[k]; !ok {
+			t.Errorf("payload JSON missing %q key", k)
+		}
+	}
+	// Truncated flags omitted when false.
+	if _, ok := round["request_truncated"]; ok {
+		t.Errorf("request_truncated:false should be omitempty")
+	}
+}
+
+func TestEvent_PayloadOmittedWhenNil(t *testing.T) {
+	ev := NewEvent("echo")
+	b, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var round map[string]any
+	_ = json.Unmarshal(b, &round)
+	if _, ok := round["payload"]; ok {
+		t.Errorf("payload key should be omitted when nil; got %s", b)
+	}
+}

--- a/pkg/audit/logger.go
+++ b/pkg/audit/logger.go
@@ -5,7 +5,10 @@ import (
 	"time"
 )
 
-// Logger writes events and queries them back for the portal.
+// Logger writes events and queries them back for the portal. Loggers
+// that capture the audit_payloads sibling row implement PayloadLogger
+// for the detail-fetch path; basic implementations (memory, noop) only
+// hold the indexable summary.
 type Logger interface {
 	Log(ctx context.Context, ev Event) error
 	Query(ctx context.Context, f QueryFilter) ([]Event, error)
@@ -13,6 +16,13 @@ type Logger interface {
 	TimeSeries(ctx context.Context, from, to time.Time, bucket time.Duration) ([]TimePoint, error)
 	Breakdown(ctx context.Context, from, to time.Time, dimension string) ([]BreakdownPoint, error)
 	Stats(ctx context.Context, from, to time.Time) (Stats, error)
+}
+
+// PayloadLogger is the optional capability for detail fetch. Stores that
+// persist the audit_payloads sibling row implement it; consumers type-
+// assert for it before calling GetPayload.
+type PayloadLogger interface {
+	GetPayload(ctx context.Context, eventID string) (*Payload, error)
 }
 
 // TimePoint is one bucket of an audit time series.
@@ -49,6 +59,7 @@ type QueryFilter struct {
 	ToolName  string
 	UserID    string
 	SessionID string
+	EventID   string // exact-match on audit_events.id (single-event fetch)
 	Success   *bool
 	Search    string
 	Limit     int

--- a/pkg/audit/memory.go
+++ b/pkg/audit/memory.go
@@ -220,10 +220,16 @@ func breakdownKeyFn(dimension string) func(Event) string {
 }
 
 func matchesFilter(ev Event, f QueryFilter) bool {
+	if f.EventID != "" && ev.ID != f.EventID {
+		return false
+	}
 	if f.ToolName != "" && ev.ToolName != f.ToolName {
 		return false
 	}
 	if f.UserID != "" && ev.UserSubject != f.UserID {
+		return false
+	}
+	if f.SessionID != "" && ev.SessionID != f.SessionID {
 		return false
 	}
 	if !f.From.IsZero() && ev.Timestamp.Before(f.From) {

--- a/pkg/audit/postgres/store.go
+++ b/pkg/audit/postgres/store.go
@@ -26,7 +26,10 @@ func New(pool *pgxpool.Pool) *Store {
 	return &Store{pool: pool}
 }
 
-// Log inserts a single event.
+// Log inserts a single event. When ev.Payload is non-nil, the matching
+// row is also inserted into audit_payloads in the same transaction so
+// the summary and detail are committed atomically. A failure on either
+// rolls back both; the async drain treats the pair as a single drop.
 func (s *Store) Log(ctx context.Context, ev audit.Event) error {
 	if ev.ID == "" {
 		ev.ID = uuid.NewString()
@@ -40,7 +43,14 @@ func (s *Store) Log(ctx context.Context, ev audit.Event) error {
 		paramsJSON = b
 	}
 
-	_, err := s.pool.Exec(ctx, `
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	// Roll back if we don't reach the commit; safe no-op after commit.
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	_, err = tx.Exec(ctx, `
 		INSERT INTO audit_events (
 			id, ts, duration_ms, request_id, session_id,
 			user_subject, user_email, auth_type, api_key_name,
@@ -67,7 +77,173 @@ func (s *Store) Log(ctx context.Context, ev audit.Event) error {
 	if err != nil {
 		return fmt.Errorf("insert audit event: %w", err)
 	}
+
+	if ev.Payload != nil {
+		if err := insertPayload(ctx, tx, ev.ID, ev.Payload); err != nil {
+			return err
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit audit event: %w", err)
+	}
 	return nil
+}
+
+// insertPayload writes the audit_payloads row for an event. Caller must
+// hold an open tx; this function never commits or rolls back on its own.
+func insertPayload(ctx context.Context, tx pgx.Tx, eventID string, p *audit.Payload) error {
+	requestParams, err := marshalJSONB(p.RequestParams)
+	if err != nil {
+		return fmt.Errorf("marshal request_params: %w", err)
+	}
+	requestHeaders, err := marshalJSONB(p.RequestHeaders)
+	if err != nil {
+		return fmt.Errorf("marshal request_headers: %w", err)
+	}
+	responseResult, err := marshalJSONB(p.ResponseResult)
+	if err != nil {
+		return fmt.Errorf("marshal response_result: %w", err)
+	}
+	responseError, err := marshalJSONB(p.ResponseError)
+	if err != nil {
+		return fmt.Errorf("marshal response_error: %w", err)
+	}
+	notifications, err := marshalJSONB(p.Notifications)
+	if err != nil {
+		return fmt.Errorf("marshal notifications: %w", err)
+	}
+	var replayedFrom any
+	if p.ReplayedFrom != "" {
+		replayedFrom = p.ReplayedFrom
+	}
+
+	_, err = tx.Exec(ctx, `
+		INSERT INTO audit_payloads (
+			event_id,
+			jsonrpc_method, jsonrpc_id,
+			request_params, request_size_bytes, request_truncated,
+			request_headers, request_method, request_path, request_remote_addr,
+			response_result, response_error, response_size_bytes, response_truncated,
+			notifications, replayed_from
+		) VALUES (
+			$1,
+			$2, $3,
+			$4, $5, $6,
+			$7, $8, $9, $10,
+			$11, $12, $13, $14,
+			$15, $16
+		)
+	`,
+		eventID,
+		p.JSONRPCMethod, p.JSONRPCID,
+		requestParams, p.RequestSizeBytes, p.RequestTruncated,
+		requestHeaders, p.RequestMethod, p.RequestPath, p.RequestRemoteAddr,
+		responseResult, responseError, p.ResponseSizeBytes, p.ResponseTruncated,
+		notifications, replayedFrom,
+	)
+	if err != nil {
+		return fmt.Errorf("insert audit payload: %w", err)
+	}
+	return nil
+}
+
+// marshalJSONB returns the JSON encoding of v, or nil for nil/empty inputs
+// so the column stores SQL NULL (which is friendlier to JSONB queries
+// than a literal "null").
+func marshalJSONB(v any) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	switch x := v.(type) {
+	case map[string]any:
+		if len(x) == 0 {
+			return nil, nil
+		}
+	case map[string][]string:
+		if len(x) == 0 {
+			return nil, nil
+		}
+	case []audit.Notification:
+		if len(x) == 0 {
+			return nil, nil
+		}
+	}
+	return json.Marshal(v)
+}
+
+// GetPayload returns the audit_payloads row for the given event, or
+// (nil, nil) if no payload was captured. Errors other than "no rows" are
+// returned.
+func (s *Store) GetPayload(ctx context.Context, eventID string) (*audit.Payload, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT
+			COALESCE(jsonrpc_method, ''),
+			COALESCE(jsonrpc_id, ''),
+			request_params,
+			request_size_bytes,
+			request_truncated,
+			request_headers,
+			COALESCE(request_method, ''),
+			COALESCE(request_path, ''),
+			COALESCE(request_remote_addr, ''),
+			response_result,
+			response_error,
+			response_size_bytes,
+			response_truncated,
+			notifications,
+			COALESCE(replayed_from, '')
+		FROM audit_payloads
+		WHERE event_id = $1
+	`, eventID)
+
+	var (
+		p              audit.Payload
+		paramsB        []byte
+		headersB       []byte
+		resultB        []byte
+		errB           []byte
+		notificationsB []byte
+	)
+	err := row.Scan(
+		&p.JSONRPCMethod,
+		&p.JSONRPCID,
+		&paramsB,
+		&p.RequestSizeBytes,
+		&p.RequestTruncated,
+		&headersB,
+		&p.RequestMethod,
+		&p.RequestPath,
+		&p.RequestRemoteAddr,
+		&resultB,
+		&errB,
+		&p.ResponseSizeBytes,
+		&p.ResponseTruncated,
+		&notificationsB,
+		&p.ReplayedFrom,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if len(paramsB) > 0 {
+		_ = json.Unmarshal(paramsB, &p.RequestParams)
+	}
+	if len(headersB) > 0 {
+		_ = json.Unmarshal(headersB, &p.RequestHeaders)
+	}
+	if len(resultB) > 0 {
+		_ = json.Unmarshal(resultB, &p.ResponseResult)
+	}
+	if len(errB) > 0 {
+		_ = json.Unmarshal(errB, &p.ResponseError)
+	}
+	if len(notificationsB) > 0 {
+		_ = json.Unmarshal(notificationsB, &p.Notifications)
+	}
+	return &p, nil
 }
 
 // Query returns matching events. ORDER is by ts DESC unless f.OrderDesc is false.
@@ -274,6 +450,9 @@ func buildSelect(f audit.QueryFilter, count bool) (string, []any) {
 	}
 	if f.SessionID != "" {
 		add("session_id = $%d", f.SessionID)
+	}
+	if f.EventID != "" {
+		add("id = $%d", f.EventID)
 	}
 	if f.Success != nil {
 		add("success = $%d", *f.Success)

--- a/pkg/config/audit_helpers_test.go
+++ b/pkg/config/audit_helpers_test.go
@@ -1,0 +1,40 @@
+package config
+
+import "testing"
+
+func TestAuditConfig_CapturePayloadsEnabled(t *testing.T) {
+	// Unset → default true.
+	c := AuditConfig{}
+	if !c.CapturePayloadsEnabled() {
+		t.Error("unset CapturePayloads should default true")
+	}
+	// Explicit true.
+	tr := true
+	c = AuditConfig{CapturePayloads: &tr}
+	if !c.CapturePayloadsEnabled() {
+		t.Error("explicit true not honored")
+	}
+	// Explicit false.
+	fa := false
+	c = AuditConfig{CapturePayloads: &fa}
+	if c.CapturePayloadsEnabled() {
+		t.Error("explicit false not honored")
+	}
+}
+
+func TestAuditConfig_CaptureHeadersEnabled(t *testing.T) {
+	c := AuditConfig{}
+	if !c.CaptureHeadersEnabled() {
+		t.Error("unset CaptureHeaders should default true")
+	}
+	tr := true
+	c = AuditConfig{CaptureHeaders: &tr}
+	if !c.CaptureHeadersEnabled() {
+		t.Error("explicit true not honored")
+	}
+	fa := false
+	c = AuditConfig{CaptureHeaders: &fa}
+	if c.CaptureHeadersEnabled() {
+		t.Error("explicit false not honored")
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -139,10 +139,56 @@ type DatabaseConfig struct {
 }
 
 // AuditConfig controls audit log behavior and parameter redaction.
+//
+// Payload capture (request/response envelope, headers, notifications) is
+// on by default because mcp-test is a test fixture and full visibility is
+// the entire point. Operators in privacy-sensitive deployments can flip
+// CapturePayloads off to keep only the indexable summary.
+//
+// CapturePayloads and CaptureHeaders are *bool so the YAML decoder can
+// tell "field absent" (use the default) from "explicitly set to false"
+// (operator opted out). Helper methods CapturePayloadsEnabled and
+// CaptureHeadersEnabled hide the pointer indirection from callers.
 type AuditConfig struct {
 	Enabled       bool     `yaml:"enabled"`
 	RetentionDays int      `yaml:"retention_days"`
 	RedactKeys    []string `yaml:"redact_keys"`
+
+	// CapturePayloads enables writing the audit_payloads sibling row
+	// alongside each summary. Default true (nil pointer = unset = on).
+	CapturePayloads *bool `yaml:"capture_payloads"`
+
+	// CaptureHeaders includes the redacted HTTP request headers in the
+	// payload row. Default true; set false in deployments where headers
+	// carry data the operator doesn't want stored even after redaction.
+	CaptureHeaders *bool `yaml:"capture_headers"`
+
+	// MaxPayloadBytes caps per-side (request, response) payload size.
+	// Anything beyond is dropped and the matching truncated flag is set.
+	// Default 65536.
+	MaxPayloadBytes int `yaml:"max_payload_bytes"`
+
+	// MaxNotifications caps the number of notifications stored per call.
+	// Default 100.
+	MaxNotifications int `yaml:"max_notifications"`
+}
+
+// CapturePayloadsEnabled returns true unless the operator explicitly set
+// CapturePayloads to false.
+func (a AuditConfig) CapturePayloadsEnabled() bool {
+	if a.CapturePayloads == nil {
+		return true
+	}
+	return *a.CapturePayloads
+}
+
+// CaptureHeadersEnabled returns true unless the operator explicitly set
+// CaptureHeaders to false.
+func (a AuditConfig) CaptureHeadersEnabled() bool {
+	if a.CaptureHeaders == nil {
+		return true
+	}
+	return *a.CaptureHeaders
 }
 
 // PortalConfig configures the embedded React portal and its session cookie.
@@ -231,6 +277,12 @@ func (c *Config) applyDefaults() {
 	}
 	if c.Audit.RetentionDays == 0 {
 		c.Audit.RetentionDays = 30
+	}
+	if c.Audit.MaxPayloadBytes == 0 {
+		c.Audit.MaxPayloadBytes = 65536
+	}
+	if c.Audit.MaxNotifications == 0 {
+		c.Audit.MaxNotifications = 100
 	}
 	if len(c.Audit.RedactKeys) == 0 {
 		// Matched as case-insensitive substrings against parameter keys

--- a/pkg/database/migrate/migrations/0002_audit_payloads.down.sql
+++ b/pkg/database/migrate/migrations/0002_audit_payloads.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS audit_payloads_response_gin;
+DROP INDEX IF EXISTS audit_payloads_request_gin;
+DROP INDEX IF EXISTS audit_payloads_replayed_from_idx;
+DROP TABLE IF EXISTS audit_payloads;

--- a/pkg/database/migrate/migrations/0002_audit_payloads.up.sql
+++ b/pkg/database/migrate/migrations/0002_audit_payloads.up.sql
@@ -1,0 +1,51 @@
+-- Adds the sibling audit_payloads table that carries the full request and
+-- response detail for an audit_events row. Two-table model keeps the
+-- summary row (used for indexed time/user/tool queries) free of multi-KB
+-- JSONB blobs; the detail join only runs when an operator drills into a
+-- single event in the portal.
+--
+-- Cascade delete keeps retention cleanup atomic: deleting an audit_events
+-- row drops its payload row in the same statement, no second policy.
+
+CREATE TABLE IF NOT EXISTS audit_payloads (
+    event_id              TEXT PRIMARY KEY REFERENCES audit_events(id) ON DELETE CASCADE,
+
+    -- JSON-RPC envelope as received
+    jsonrpc_method        TEXT,
+    jsonrpc_id            TEXT,
+    request_params        JSONB,
+    request_size_bytes    INTEGER NOT NULL DEFAULT 0,
+    request_truncated     BOOLEAN NOT NULL DEFAULT false,
+
+    -- HTTP layer
+    request_headers       JSONB,
+    request_method        TEXT,
+    request_path          TEXT,
+    request_remote_addr   TEXT,
+
+    -- JSON-RPC response
+    response_result       JSONB,
+    response_error        JSONB,
+    response_size_bytes   INTEGER NOT NULL DEFAULT 0,
+    response_truncated    BOOLEAN NOT NULL DEFAULT false,
+
+    -- Notifications fired during the call window: array of {ts, method, params}
+    notifications         JSONB,
+
+    -- Replay linkage; ON DELETE SET NULL so deleting the original doesn't
+    -- cascade into the replay's payload row.
+    replayed_from         TEXT REFERENCES audit_events(id) ON DELETE SET NULL,
+
+    captured_at           TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS audit_payloads_replayed_from_idx
+    ON audit_payloads (replayed_from)
+    WHERE replayed_from IS NOT NULL;
+
+-- jsonb_path_ops indexes: smaller and faster than the default GIN for the
+-- @> containment operator we use in the JSONB path filter compiler.
+CREATE INDEX IF NOT EXISTS audit_payloads_request_gin
+    ON audit_payloads USING gin (request_params jsonb_path_ops);
+CREATE INDEX IF NOT EXISTS audit_payloads_response_gin
+    ON audit_payloads USING gin (response_result jsonb_path_ops);

--- a/pkg/httpsrv/portal_api.go
+++ b/pkg/httpsrv/portal_api.go
@@ -35,6 +35,7 @@ func (p *PortalAPI) Mount(mux *http.ServeMux, mw func(http.Handler) http.Handler
 	mux.Handle("GET /api/v1/portal/tools", mw(http.HandlerFunc(p.tools)))
 	mux.Handle("GET /api/v1/portal/tools/{name}", mw(http.HandlerFunc(p.toolDetail)))
 	mux.Handle("GET /api/v1/portal/audit/events", mw(http.HandlerFunc(p.auditEvents)))
+	mux.Handle("GET /api/v1/portal/audit/events/{id}", mw(http.HandlerFunc(p.auditEventDetail)))
 	mux.Handle("GET /api/v1/portal/audit/timeseries", mw(http.HandlerFunc(p.auditTimeseries)))
 	mux.Handle("GET /api/v1/portal/audit/breakdown", mw(http.HandlerFunc(p.auditBreakdown)))
 	mux.Handle("GET /api/v1/portal/dashboard", mw(http.HandlerFunc(p.dashboard)))
@@ -163,6 +164,52 @@ func (p *PortalAPI) auditEvents(w http.ResponseWriter, r *http.Request) {
 		"limit":  f.Limit,
 		"offset": f.Offset,
 	})
+}
+
+// auditEventDetail returns a single event identified by ID, plus its
+// audit_payloads sibling row (when capture is enabled and the row was
+// recorded). Loggers that don't persist payloads (memory, noop) return
+// the summary alone with payload omitted.
+//
+// Response shape mirrors the Event JSON marshaling; when payload was
+// captured, it appears under the "payload" key.
+func (p *PortalAPI) auditEventDetail(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("event id required"))
+		return
+	}
+
+	// The Logger interface doesn't have a single-event lookup; reuse Query
+	// with a bounded filter and pluck the matching row. This is O(scan)
+	// today; if event detail becomes a hot path we can add a primary-key
+	// fetch to the interface.
+	events, err := p.audit.Query(r.Context(), audit.QueryFilter{Limit: 1, EventID: id})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	if len(events) == 0 {
+		writeError(w, http.StatusNotFound, fmt.Errorf("event %q not found", id))
+		return
+	}
+	ev := events[0]
+
+	// Payload on the in-memory event (if any) is from the original
+	// write path and shouldn't be returned to the client; the truth
+	// for "what's in the audit_payloads table" is what GetPayload
+	// returns. Reset and ask the logger.
+	ev.Payload = nil
+	if pl, ok := p.audit.(audit.PayloadLogger); ok {
+		payload, perr := pl.GetPayload(r.Context(), id)
+		if perr == nil {
+			ev.Payload = payload
+		}
+		// Soft-fail on perr: the summary is real, only detail is
+		// unavailable; the binary's logs carry the error.
+	}
+
+	writeJSON(w, http.StatusOK, ev)
 }
 
 // maxTimeseriesWindow caps the requested time-series window at 30 days

--- a/pkg/httpsrv/portal_api_detail_test.go
+++ b/pkg/httpsrv/portal_api_detail_test.go
@@ -1,0 +1,75 @@
+package httpsrv
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/plexara/mcp-test/pkg/audit"
+)
+
+func TestPortalAPI_AuditEventDetail_Found(t *testing.T) {
+	mem := audit.NewMemoryLogger()
+	ev := audit.Event{
+		ID:        "evt-123",
+		ToolName:  "echo",
+		Success:   true,
+		Transport: "http",
+		Source:    "mcp",
+	}
+	_ = mem.Log(context.Background(), ev)
+
+	mux := portalTestMux(t, mem)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/portal/audit/events/evt-123", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	var got map[string]any
+	_ = json.NewDecoder(w.Body).Decode(&got)
+	if got["id"] != "evt-123" {
+		t.Errorf("id = %v", got["id"])
+	}
+	if got["tool_name"] != "echo" {
+		t.Errorf("tool_name = %v", got["tool_name"])
+	}
+}
+
+func TestPortalAPI_AuditEventDetail_NotFound(t *testing.T) {
+	mux := portalTestMux(t, audit.NewMemoryLogger())
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/portal/audit/events/missing", nil))
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestPortalAPI_AuditEventDetail_PayloadAbsentForMemoryLogger(t *testing.T) {
+	mem := audit.NewMemoryLogger()
+	ev := audit.Event{
+		ID:        "evt-456",
+		ToolName:  "echo",
+		Transport: "http",
+		Source:    "mcp",
+		// MemoryLogger doesn't persist payloads even if attached, so the
+		// detail endpoint should return summary only.
+		Payload: &audit.Payload{JSONRPCMethod: "tools/call"},
+	}
+	_ = mem.Log(context.Background(), ev)
+
+	mux := portalTestMux(t, mem)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/portal/audit/events/evt-456", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var got map[string]any
+	_ = json.NewDecoder(w.Body).Decode(&got)
+	// MemoryLogger isn't a PayloadLogger, so the detail handler clears
+	// the field to nil; serialized JSON should omit it.
+	if _, ok := got["payload"]; ok {
+		t.Errorf("payload should be omitted for non-payload logger; body=%v", got)
+	}
+}

--- a/pkg/mcpmw/audit.go
+++ b/pkg/mcpmw/audit.go
@@ -3,6 +3,7 @@ package mcpmw
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
@@ -15,6 +16,57 @@ import (
 	"github.com/plexara/mcp-test/pkg/auth"
 )
 
+// AuditOption configures the Audit middleware. Without options the
+// middleware records the indexable summary only (matching pre-payload
+// behavior); options opt into full request/response capture, header
+// capture, and notification recording.
+type AuditOption func(*auditOptions)
+
+type auditOptions struct {
+	capturePayloads  bool
+	captureHeaders   bool
+	maxPayloadBytes  int
+	maxNotifications int
+}
+
+func defaultAuditOptions() auditOptions {
+	return auditOptions{
+		capturePayloads:  false,
+		captureHeaders:   false,
+		maxPayloadBytes:  65536,
+		maxNotifications: 100,
+	}
+}
+
+// WithPayloadCapture turns on the audit_payloads sibling-row capture.
+// maxBytes caps each side (request, response) of the captured envelope;
+// content beyond is dropped and the matching truncated flag is set on
+// the payload row. Pass <=0 to use the default 65536.
+func WithPayloadCapture(maxBytes int) AuditOption {
+	return func(o *auditOptions) {
+		o.capturePayloads = true
+		if maxBytes > 0 {
+			o.maxPayloadBytes = maxBytes
+		}
+	}
+}
+
+// WithHeaderCapture stores the redacted HTTP request headers in the
+// payload row. Has no effect unless WithPayloadCapture is also set.
+func WithHeaderCapture() AuditOption {
+	return func(o *auditOptions) { o.captureHeaders = true }
+}
+
+// WithMaxNotifications caps the number of notifications recorded per
+// call. Default 100. Has no effect unless WithPayloadCapture is set.
+func WithMaxNotifications(n int) AuditOption {
+	return func(o *auditOptions) {
+		if n > 0 {
+			o.maxNotifications = n
+		}
+	}
+}
+
 // Audit returns a Middleware that records every tools/call invocation.
 //
 // The middleware:
@@ -25,7 +77,12 @@ import (
 //
 // Even if authentication fails the row is written, so failed calls show up in
 // the audit log alongside successful ones.
-func Audit(chain *auth.Chain, logger audit.Logger, redactKeys []string, toolGroups map[string]string) mcp.Middleware {
+func Audit(chain *auth.Chain, logger audit.Logger, redactKeys []string, toolGroups map[string]string, opts ...AuditOption) mcp.Middleware {
+	o := defaultAuditOptions()
+	for _, fn := range opts {
+		fn(&o)
+	}
+
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
 		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
 			if method != "tools/call" {
@@ -70,6 +127,9 @@ func Audit(chain *auth.Chain, logger audit.Logger, redactKeys []string, toolGrou
 			if authErr != nil {
 				ev.WithResult(false, authErr.Error(), time.Since(start).Milliseconds())
 				ev.ErrorCategory = "auth"
+				if o.capturePayloads {
+					ev.WithPayload(buildPayload(ctx, req, params, redactKeys, nil, authErr, o, nil))
+				}
 				_ = logger.Log(ctx, *ev)
 				return nil, authErr
 			}
@@ -78,7 +138,9 @@ func Audit(chain *auth.Chain, logger audit.Logger, redactKeys []string, toolGrou
 
 			res, err := next(ctx, method, req)
 			ev.WithResult(err == nil, errString(err), time.Since(start).Milliseconds())
-			if cr, ok := res.(*mcp.CallToolResult); ok && cr != nil {
+			var cr *mcp.CallToolResult
+			if r, ok := res.(*mcp.CallToolResult); ok && r != nil {
+				cr = r
 				chars, blocks := measureResult(cr)
 				ev.WithResponseSize(chars, blocks)
 				if cr.IsError && err == nil {
@@ -86,10 +148,152 @@ func Audit(chain *auth.Chain, logger audit.Logger, redactKeys []string, toolGrou
 					ev.ErrorCategory = "tool"
 				}
 			}
+			if o.capturePayloads {
+				ev.WithPayload(buildPayload(ctx, req, params, redactKeys, cr, err, o, nil))
+			}
 			_ = logger.Log(ctx, *ev)
 			return res, err
 		}
 	}
+}
+
+// buildPayload assembles the full audit_payloads row for one tools/call.
+// The notifications slice is captured by the caller via a session
+// recorder (see notification.go); pass nil when no recording was wired.
+//
+// Each side (request, response) is size-bounded; oversize JSON content
+// is dropped wholesale and the matching truncated flag is set. Headers
+// are reflected exactly as ctx already carries them (the audit
+// middleware clones + redacts them in enrichContext via the caller's
+// HeaderCapture middleware).
+func buildPayload(
+	ctx context.Context,
+	_ mcp.Request,
+	rawParams map[string]any,
+	redactKeys []string,
+	cr *mcp.CallToolResult,
+	callErr error,
+	opts auditOptions,
+	notifications []audit.Notification,
+) *audit.Payload {
+	p := &audit.Payload{
+		JSONRPCMethod:     "tools/call",
+		RequestRemoteAddr: auth.GetRemoteAddr(ctx),
+	}
+
+	// Request: the sanitized params already live on Event.Parameters,
+	// but we duplicate here so the payload row is self-contained.
+	sanitized := audit.SanitizeParameters(rawParams, redactKeys)
+	if size, ok := jsonSizeWithin(sanitized, opts.maxPayloadBytes); ok {
+		p.RequestParams = sanitized
+		p.RequestSizeBytes = size
+	} else {
+		p.RequestTruncated = true
+		p.RequestSizeBytes = size
+	}
+
+	// Headers: only when the operator opted in. enrichContext already
+	// cloned the inbound header set; HeaderCapture (HTTP layer) is
+	// responsible for stripping Authorization / Cookie before they
+	// reach ctx.
+	if opts.captureHeaders {
+		if h := auth.GetHeaders(ctx); h != nil {
+			p.RequestHeaders = map[string][]string(h)
+		}
+	}
+
+	// Response: serialize the CallToolResult content blocks. We model
+	// the result as a {content:[...], isError:bool, structuredContent:?}
+	// shape to match the SDK's wire format so the portal can render
+	// each block by type.
+	if cr != nil {
+		result := callToolResultToMap(cr)
+		if size, ok := jsonSizeWithin(result, opts.maxPayloadBytes); ok {
+			p.ResponseResult = result
+			p.ResponseSizeBytes = size
+		} else {
+			p.ResponseTruncated = true
+			p.ResponseSizeBytes = size
+		}
+	}
+
+	// Errors land in response_error so the portal can render them
+	// distinct from a tool that returned IsError=true.
+	if callErr != nil {
+		p.ResponseError = map[string]any{
+			"message": callErr.Error(),
+		}
+	}
+
+	// Notifications captured by the recorder, capped per opts.
+	if len(notifications) > 0 {
+		max := opts.maxNotifications
+		if max > 0 && len(notifications) > max {
+			notifications = notifications[:max]
+		}
+		p.Notifications = notifications
+	}
+
+	return p
+}
+
+// callToolResultToMap renders a CallToolResult in the same shape the
+// MCP SDK serializes to the wire, so portal consumers can iterate
+// content blocks by type without reflection on Go-only types.
+func callToolResultToMap(cr *mcp.CallToolResult) map[string]any {
+	out := map[string]any{
+		"isError": cr.IsError,
+	}
+	blocks := make([]any, 0, len(cr.Content))
+	for _, c := range cr.Content {
+		switch v := c.(type) {
+		case *mcp.TextContent:
+			blocks = append(blocks, map[string]any{
+				"type": "text",
+				"text": v.Text,
+			})
+		case *mcp.ImageContent:
+			blocks = append(blocks, map[string]any{
+				"type":     "image",
+				"mimeType": v.MIMEType,
+				"data":     v.Data,
+			})
+		case *mcp.AudioContent:
+			blocks = append(blocks, map[string]any{
+				"type":     "audio",
+				"mimeType": v.MIMEType,
+				"data":     v.Data,
+			})
+		default:
+			blocks = append(blocks, map[string]any{
+				"type":  "unknown",
+				"shape": "non-textual content block",
+			})
+		}
+	}
+	out["content"] = blocks
+	if cr.StructuredContent != nil {
+		out["structuredContent"] = cr.StructuredContent
+	}
+	return out
+}
+
+// jsonSizeWithin reports the JSON byte size of v and whether it falls
+// within max. A non-positive max means "no limit" and always returns
+// (size, true).
+func jsonSizeWithin(v any, max int) (int, bool) {
+	if v == nil {
+		return 0, true
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return 0, false
+	}
+	size := len(b)
+	if max <= 0 {
+		return size, true
+	}
+	return size, size <= max
 }
 
 // enrichContext attaches request metadata (headers, token, request ID, remote

--- a/pkg/mcpmw/audit_payload_test.go
+++ b/pkg/mcpmw/audit_payload_test.go
@@ -1,0 +1,185 @@
+package mcpmw
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/plexara/mcp-test/pkg/audit"
+	"github.com/plexara/mcp-test/pkg/auth"
+)
+
+func TestAudit_NoOptions_NoPayloadCaptured(t *testing.T) {
+	mem := audit.NewMemoryLogger()
+	chain := auth.NewChain(true, nil, nil)
+	mw := Audit(chain, mem, nil, nil) // no opts → no capture
+	wrapped := mw((&fakeMethodHandler{
+		res: &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "ok"}}},
+	}).handle)
+
+	req := &mcp.ServerRequest[*mcp.CallToolParams]{
+		Params: &mcp.CallToolParams{Name: "echo", Arguments: map[string]any{"k": "v"}},
+		Extra:  &mcp.RequestExtra{Header: http.Header{"User-Agent": []string{"test"}}},
+	}
+	_, _ = wrapped(context.Background(), "tools/call", req)
+	events := mem.Snapshot()
+	if len(events) != 1 {
+		t.Fatalf("events = %d", len(events))
+	}
+	if events[0].Payload != nil {
+		t.Errorf("expected nil payload without WithPayloadCapture")
+	}
+}
+
+func TestAudit_WithPayloadCapture_FillsRequestAndResponse(t *testing.T) {
+	mem := audit.NewMemoryLogger()
+	chain := auth.NewChain(true, nil, nil)
+	mw := Audit(chain, mem, []string{"password"}, nil,
+		WithPayloadCapture(0), // 0 → default 65536
+	)
+	wrapped := mw((&fakeMethodHandler{
+		res: &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "hello"},
+				&mcp.TextContent{Text: " world"},
+			},
+		},
+	}).handle)
+
+	req := &mcp.ServerRequest[*mcp.CallToolParams]{
+		Params: &mcp.CallToolParams{Name: "echo", Arguments: map[string]any{
+			"message":  "hi",
+			"password": "should-be-redacted",
+		}},
+		Extra: &mcp.RequestExtra{Header: http.Header{
+			"User-Agent": []string{"test"},
+		}},
+	}
+	_, _ = wrapped(context.Background(), "tools/call", req)
+	events := mem.Snapshot()
+	if len(events) != 1 {
+		t.Fatalf("events = %d", len(events))
+	}
+	p := events[0].Payload
+	if p == nil {
+		t.Fatal("expected non-nil payload")
+	}
+	if p.JSONRPCMethod != "tools/call" {
+		t.Errorf("JSONRPCMethod = %q", p.JSONRPCMethod)
+	}
+	// Sanitization carried over.
+	if pw, _ := p.RequestParams["password"].(string); pw != "[redacted]" {
+		t.Errorf("password not redacted in payload: %v", p.RequestParams["password"])
+	}
+	if msg, _ := p.RequestParams["message"].(string); msg != "hi" {
+		t.Errorf("message not preserved: %v", p.RequestParams["message"])
+	}
+	// Response shape.
+	result := p.ResponseResult
+	if result == nil {
+		t.Fatal("expected non-nil response_result")
+	}
+	if isErr, _ := result["isError"].(bool); isErr {
+		t.Errorf("isError should be false")
+	}
+	blocks, _ := result["content"].([]any)
+	if len(blocks) != 2 {
+		t.Errorf("expected 2 content blocks, got %d", len(blocks))
+	}
+	if p.RequestSizeBytes <= 0 || p.ResponseSizeBytes <= 0 {
+		t.Errorf("size fields not populated: req=%d resp=%d", p.RequestSizeBytes, p.ResponseSizeBytes)
+	}
+	if p.RequestTruncated || p.ResponseTruncated {
+		t.Errorf("unexpected truncation: %+v", p)
+	}
+}
+
+func TestAudit_PayloadCapture_TruncatesOversizeResponse(t *testing.T) {
+	mem := audit.NewMemoryLogger()
+	chain := auth.NewChain(true, nil, nil)
+	// Tight cap that the response will exceed.
+	mw := Audit(chain, mem, nil, nil, WithPayloadCapture(8))
+	huge := strings.Repeat("x", 10_000)
+	wrapped := mw((&fakeMethodHandler{
+		res: &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: huge}}},
+	}).handle)
+
+	req := &mcp.ServerRequest[*mcp.CallToolParams]{
+		Params: &mcp.CallToolParams{Name: "long_output"},
+		Extra:  &mcp.RequestExtra{Header: http.Header{}},
+	}
+	_, _ = wrapped(context.Background(), "tools/call", req)
+	p := mem.Snapshot()[0].Payload
+	if p == nil {
+		t.Fatal("expected payload")
+	}
+	if !p.ResponseTruncated {
+		t.Error("expected ResponseTruncated=true for oversize response")
+	}
+	if p.ResponseResult != nil {
+		t.Errorf("oversize response should be dropped, got: %+v", p.ResponseResult)
+	}
+	if p.ResponseSizeBytes <= 8 {
+		t.Errorf("size still recorded; got %d", p.ResponseSizeBytes)
+	}
+}
+
+func TestAudit_PayloadCapture_HeadersOptIn(t *testing.T) {
+	mem := audit.NewMemoryLogger()
+	chain := auth.NewChain(true, nil, nil)
+
+	// Without WithHeaderCapture: headers not captured.
+	mw := Audit(chain, mem, nil, nil, WithPayloadCapture(0))
+	req := &mcp.ServerRequest[*mcp.CallToolParams]{
+		Params: &mcp.CallToolParams{Name: "headers"},
+		Extra:  &mcp.RequestExtra{Header: http.Header{"X-Test": []string{"abc"}}},
+	}
+	wrapped := mw((&fakeMethodHandler{}).handle)
+	_, _ = wrapped(context.Background(), "tools/call", req)
+	if h := mem.Snapshot()[0].Payload.RequestHeaders; h != nil {
+		t.Errorf("headers captured without opt-in: %+v", h)
+	}
+
+	// With WithHeaderCapture: headers stored.
+	mem2 := audit.NewMemoryLogger()
+	mw2 := Audit(chain, mem2, nil, nil, WithPayloadCapture(0), WithHeaderCapture())
+	wrapped2 := mw2((&fakeMethodHandler{}).handle)
+	_, _ = wrapped2(context.Background(), "tools/call", req)
+	h := mem2.Snapshot()[0].Payload.RequestHeaders
+	if h == nil {
+		t.Fatal("expected headers captured with WithHeaderCapture")
+	}
+	if got := h["X-Test"]; len(got) != 1 || got[0] != "abc" {
+		t.Errorf("X-Test = %v", got)
+	}
+}
+
+func TestAudit_AuthFailure_StillCapturesPayload(t *testing.T) {
+	mem := audit.NewMemoryLogger()
+	chain := auth.NewChain(false, nil, nil) // no anonymous, no stores → auth fails
+	mw := Audit(chain, mem, nil, nil, WithPayloadCapture(0))
+	wrapped := mw((&fakeMethodHandler{}).handle)
+
+	req := &mcp.ServerRequest[*mcp.CallToolParams]{
+		Params: &mcp.CallToolParams{Name: "echo", Arguments: map[string]any{"a": 1}},
+		Extra:  &mcp.RequestExtra{Header: http.Header{"User-Agent": []string{"x"}}},
+	}
+	_, err := wrapped(context.Background(), "tools/call", req)
+	if !errors.Is(err, auth.ErrNotAuthenticated) {
+		t.Fatalf("err = %v", err)
+	}
+	events := mem.Snapshot()
+	if len(events) != 1 {
+		t.Fatalf("events = %d", len(events))
+	}
+	if events[0].Payload == nil {
+		t.Fatal("expected payload even on auth failure")
+	}
+	if events[0].Payload.ResponseError == nil {
+		t.Errorf("expected ResponseError on auth-failure payload")
+	}
+}


### PR DESCRIPTION
First slice of [#4](https://github.com/plexara/mcp-test/issues/4). Lays the data + API foundation for the inspection utility. UI rewrite, replay, SSE tail, comparison, JSONB filter compiler, NDJSON export, and the notification recorder land as separate follow-up PRs on top of this.

## What's in this PR

### Schema

- `pkg/database/migrate/migrations/0002_audit_payloads.up.sql` / `.down.sql`
- New `audit_payloads` table joined 1:1 with `audit_events` by `event_id`, FK `ON DELETE CASCADE` so retention scrubs both tables in one statement.
- `jsonb_path_ops` GIN indexes on `request_params` and `response_result` (smaller and faster than default GIN for the `@>` operators the filter compiler will use).
- `replayed_from` FK with `ON DELETE SET NULL` so replay rows survive the deletion of their original.

### Types and JSON shape

- `audit.Payload` carries the JSON-RPC envelope (method, id, params), HTTP layer fields (headers, method, path, remote_addr), the response (result, error, sizes, truncation flags), notifications fired during the call window, and replay linkage. All `omitempty` so the wire shape stays compact when fields are absent.
- `audit.Notification {ts, method, params}` for the recorder follow-up.
- `audit.Event` gains a `Payload` pointer and `WithPayload` setter; nil is the wire default so existing summary-only consumers see no change.

### Config

- `AuditConfig.CapturePayloads` and `CaptureHeaders` are `*bool` so YAML can distinguish "absent" (default-on) from "explicitly false" (operator opt-out).
- `MaxPayloadBytes` (default 65536) and `MaxNotifications` (default 100) cap per-call storage.
- `CapturePayloadsEnabled()` / `CaptureHeadersEnabled()` helpers hide the pointer indirection.

### Logger interface

- New optional `audit.PayloadLogger` capability. `AsyncLogger` delegates `GetPayload` when the inner store implements it. `MemoryLogger` and `NoopLogger` don't, so the portal detail endpoint returns the summary alone for those stores; tests assert this.

### Postgres store

- `Log` opens a `pgx.Tx`, inserts `audit_events`, then inserts `audit_payloads` if non-nil, commits or rolls back as a pair. Half-written rows are not possible.
- `marshalJSONB` returns SQL `NULL` (not the literal string `"null"`) for empty maps and slices so JSONB queries behave as operators expect.
- `GetPayload` reads the sibling row by `event_id`, COALESCEs nullable strings to `''` for clean Go-side scanning. Returns `(nil, nil)` for events captured before this feature or with payload capture disabled.

### Capture middleware

- `mcpmw.AuditOption` functional-options pattern: `WithPayloadCapture(maxBytes int)`, `WithHeaderCapture()`, `WithMaxNotifications(n int)`. The `Audit()` signature stays backward-compatible (variadic opts at the end).
- `buildPayload()` assembles:
  - request side from the sanitized params (already redacted via `SanitizeParameters`)
  - response side from the `*mcp.CallToolResult` content blocks rendered in SDK wire shape (`text`, `image`, `audio`, plus `structuredContent`)
  - optional headers from `auth.GetHeaders(ctx)` (only when `WithHeaderCapture` is set)
- `jsonSizeWithin` enforces `opts.maxPayloadBytes` per side. Oversize content is dropped (set to nil) and the matching `truncated` flag is set, so the portal can render "this call was too big to capture, only the size and shape are recorded" rather than displaying a partial blob.
- The auth-failure path also writes a payload row so `response_error` carries the rejection message; useful for triaging gateway auth misconfigurations.

### Server boot

- `auditOptions(cfg.Audit)` translates `AuditConfig` into the `[]mcpmw.AuditOption` slice in one place; the test path (`BuildWithDeps`) reuses it.

### Portal API

- `GET /api/v1/portal/audit/events/{id}` returns the full event with payload joined from `audit_payloads` via `PayloadLogger.GetPayload`. 404 on unknown id; payload omitted for non-`PayloadLogger` stores.
- `audit.QueryFilter` gains `EventID` for single-event lookup; both the Postgres store and the in-memory logger honor it.

## Tests

| File | Coverage |
|---|---|
| `pkg/audit/event_payload_test.go` | `WithPayload` round-trip, JSON omitempty assertions, `Event.Payload` absent in JSON when nil |
| `pkg/config/audit_helpers_test.go` | tri-state (absent / true / false) for both `*bool` helpers |
| `pkg/mcpmw/audit_payload_test.go` | no-opts captures no payload; `WithPayloadCapture` fills both sides with sanitization carried over; oversize response is truncated and dropped; `WithHeaderCapture` is opt-in; auth-failure path captures payload with `ResponseError` set |
| `pkg/httpsrv/portal_api_detail_test.go` | 200 returns event by id, 404 on missing, payload omitted when logger doesn't implement `PayloadLogger` |

`make verify` is green at >=80% filtered coverage.

## Out of scope (in #4 but later PRs)

1. **Notification recorder** ([#4 task #46]) — wraps `req.Session` so `NotifyProgress` calls land in `Payload.Notifications`. The Payload struct already supports it (the `Notifications` field is wired through schema, types, store, and middleware; only the recorder isn't built yet).
2. **Portal UI** — click-to-expand drawer on the Audit page with Overview / Request / Response / Notifications tabs.
3. **Replay endpoint** — `POST /api/v1/portal/audit/events/{id}/replay`; new audit row tagged `source=portal-replay` with `replayed_from`.
4. **SSE live tail** — `GET /audit/stream`.
5. **Comparison page** — side-by-side diff of two events.
6. **JSONB path filter compiler** — `?param.message=hello`, `?has=response_error`, etc.
7. **NDJSON export** — `GET /audit/export?format=jsonl`.
8. **Docs** — `docs/operations/inspection.md`.

## Test plan

- [x] `make verify` (lint + race-tested test suite + 80% coverage gate).
- [ ] Bring up `make dev`, hit `echo` via the portal Try-It with `arguments: {"message":"inspect-me"}`. Verify the row in `audit_events` and the matching row in `audit_payloads` (`SELECT * FROM audit_payloads WHERE event_id = '<id>'`).
- [ ] `curl -H "X-API-Key: $MCPTEST_DEV_KEY" http://localhost:8080/api/v1/portal/audit/events/<id>` returns the summary plus `payload.request_params`, `payload.response_result.content`, `payload.response_size_bytes`.
- [ ] Override `audit.max_payload_bytes: 32` in config, call `lorem` with `words: 100`, confirm the resulting `audit_payloads` row has `response_truncated: true` and `response_result: null`.
- [ ] Set `audit.capture_payloads: false` in YAML, restart, confirm new calls produce only `audit_events` rows (no `audit_payloads` rows).