### PR TITLE
feat(audit): notification capture and PR #5 review fixes (#8)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,19 +35,28 @@ UI_EMBED_DIR := ./internal/ui/dist
 GOLANGCI_LINT_VERSION := v2.11.4
 GOSEC_VERSION         := v2.25.0
 
+# Project-local tool dir. We pin lint/security tools here rather than
+# relying on whatever's on $PATH; otherwise a developer's brew-installed
+# (or newer GOPATH-installed) binary can pass `make verify` while the
+# pinned CI version fails. The directory lives under $(BUILD_DIR) so it's
+# already gitignored via /bin/.
+TOOLS_DIR := $(abspath $(BUILD_DIR)/tools)
+
 GO       := go
 GOTEST   := $(GO) test
 GOBUILD  := $(GO) build
 GOMOD    := $(GO) mod
 GOFMT    := gofmt
-GOLINT   := golangci-lint
+GOLINT   := $(TOOLS_DIR)/golangci-lint
+GOSEC    := $(TOOLS_DIR)/gosec
+GOVULN   := $(TOOLS_DIR)/govulncheck
 
 .PHONY: all build test test-short bench fmt fmt-check vet tidy clean help dev-secrets \
         ui ui-dev ui-clean embed-clean \
         lint security gosec govulncheck \
         coverage coverage-gate coverage-report \
         dead-code mutate semgrep \
-        verify tools-check \
+        verify tools-check tools-install \
         dev dev-anon dev-up dev-wait dev-ui-if-needed dev-down dev-logs \
         docker docs docs-serve screenshots run version
 
@@ -120,20 +129,20 @@ embed-clean:
 	@mkdir -p $(UI_EMBED_DIR)
 	@touch $(UI_EMBED_DIR)/.gitkeep
 
-## lint: golangci-lint run
-lint:
-	@echo "Running golangci-lint..."
-	$(GOLINT) run
+## lint: golangci-lint run (pinned version from $(TOOLS_DIR))
+lint: tools-check
+	@echo "Running golangci-lint $(GOLANGCI_LINT_VERSION)..."
+	$(GOLINT) run --timeout=5m
 
-## gosec: Static security analyzer
-gosec:
-	@echo "Running gosec..."
-	gosec -quiet ./...
+## gosec: Static security analyzer (pinned version from $(TOOLS_DIR))
+gosec: tools-check
+	@echo "Running gosec $(GOSEC_VERSION)..."
+	$(GOSEC) -quiet ./...
 
 ## govulncheck: Known-vulnerability scan
-govulncheck:
+govulncheck: tools-check
 	@echo "Running govulncheck..."
-	govulncheck ./...
+	$(GOVULN) ./...
 
 ## security: gosec + govulncheck
 security: gosec govulncheck
@@ -180,22 +189,30 @@ mutate:
 	@echo "Running gremlins (mutation testing)..."
 	gremlins unleash --workers 4 --tags-filter "!integration" ./...
 
-## tools-check: Verify required tools are installed before running verify
-tools-check:
-	@echo "Checking required tools..."
-	@missing=""; \
-	which $(GOLINT) > /dev/null 2>&1     || missing="$$missing  golangci-lint: go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)\n"; \
-	which gosec > /dev/null 2>&1         || missing="$$missing  gosec:         go install github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION)\n"; \
-	which govulncheck > /dev/null 2>&1   || missing="$$missing  govulncheck:   go install golang.org/x/vuln/cmd/govulncheck@latest\n"; \
-	if [ -n "$$missing" ]; then \
-		echo ""; \
-		echo "FAIL: missing required tools for 'make verify':"; \
-		printf "$$missing"; \
-		echo ""; \
-		exit 1; \
-	fi
-	@echo "All required tools found."
-	@# Optional tools; warn but don't fail.
+## tools-install: Install lint/security tools at the pinned versions into $(TOOLS_DIR).
+##                 Idempotent; the stamp file skips reinstall when the pinned
+##                 versions are already there. Delete bin/tools/.installed to
+##                 force a reinstall (or just bump the pinned vars).
+TOOLS_STAMP := $(TOOLS_DIR)/.installed-$(GOLANGCI_LINT_VERSION)-$(GOSEC_VERSION)
+tools-install: $(TOOLS_STAMP)
+
+$(TOOLS_STAMP):
+	@echo "Installing pinned tools into $(TOOLS_DIR)..."
+	@mkdir -p $(TOOLS_DIR)
+	@rm -f $(TOOLS_DIR)/.installed-* 2>/dev/null || true
+	GOBIN=$(TOOLS_DIR) $(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	GOBIN=$(TOOLS_DIR) $(GO) install github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION)
+	GOBIN=$(TOOLS_DIR) $(GO) install golang.org/x/vuln/cmd/govulncheck@latest
+	@touch $@
+
+## tools-check: Verify pinned lint/security tools are present at the right versions.
+##              Auto-installs (via tools-install) when missing or stale.
+tools-check: tools-install
+	@echo "Tools pinned at $(TOOLS_DIR):"
+	@echo "  golangci-lint: $$($(GOLINT) --version 2>/dev/null | head -1)"
+	@echo "  gosec:         $$($(GOSEC) --version 2>/dev/null | head -1)"
+	@echo "  govulncheck:   $$(test -x $(GOVULN) && echo present || echo MISSING)"
+	@# Optional tools (informational); warn but don't fail.
 	@which deadcode > /dev/null 2>&1 || echo "  (optional) deadcode not installed: go install golang.org/x/tools/cmd/deadcode@latest"
 	@which semgrep  > /dev/null 2>&1 || echo "  (optional) semgrep  not installed: pip3 install semgrep"
 	@which gremlins > /dev/null 2>&1 || echo "  (optional) gremlins not installed: go install github.com/go-gremlins/gremlins/cmd/gremlins@latest"

--- a/configs/mcp-test.dev.yaml
+++ b/configs/mcp-test.dev.yaml
@@ -30,6 +30,13 @@ database:
 
 audit:
   enabled: true
+  # Full request/response capture into audit_payloads for portal
+  # drill-down. Defaults are sane for a dev fixture; flip
+  # capture_payloads to false to keep summaries only.
+  capture_payloads: true
+  capture_headers: true
+  max_payload_bytes: 65536
+  max_notifications: 100
 
 portal:
   enabled: true

--- a/configs/mcp-test.example.yaml
+++ b/configs/mcp-test.example.yaml
@@ -60,6 +60,18 @@ audit:
   enabled: true
   retention_days: 30
   redact_keys: [password, token, secret, authorization, api_key, credentials, cookie]
+  # Inspection / debugging capture: full request and response envelopes
+  # land in the sibling audit_payloads table for portal drill-down. Set
+  # capture_payloads to false to keep audit_events summary-only.
+  capture_payloads: true
+  # Whether the redacted HTTP headers ride along on the payload row.
+  capture_headers: true
+  # Per-side cap (request, response). Content beyond is dropped and the
+  # truncated flag is set on the payload row. 64 KiB default; raise for
+  # debugging, lower in storage-constrained deployments.
+  max_payload_bytes: 65536
+  # Cap on notifications recorded per call.
+  max_notifications: 100
 
 portal:
   enabled: true

--- a/configs/mcp-test.live.yaml
+++ b/configs/mcp-test.live.yaml
@@ -48,6 +48,11 @@ database:
 audit:
   enabled: true
   redact_keys: [password, token, secret, authorization, cookie, api_key, credentials, bearer, jwt, session_id, private_key]
+  # Inspection capture (default-on).
+  capture_payloads: true
+  capture_headers: true
+  max_payload_bytes: 65536
+  max_notifications: 100
 
 portal:
   enabled: true

--- a/internal/server/audit_options_test.go
+++ b/internal/server/audit_options_test.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/plexara/mcp-test/pkg/config"
+)
+
+// auditOptions is the bridge between operator config and middleware
+// behavior. A regression that breaks the translation (e.g., header
+// capture accidentally always-on) wouldn't be caught by the higher-
+// level integration tests since they don't introspect the middleware
+// state. Cover the matrix here.
+func TestAuditOptions_DefaultsOn(t *testing.T) {
+	// Both *bool fields nil → CapturePayloadsEnabled / CaptureHeadersEnabled
+	// return true → both options included.
+	cfg := config.AuditConfig{}
+	opts := auditOptions(cfg)
+	if len(opts) < 2 {
+		t.Errorf("expected at least 2 opts (payload + header), got %d", len(opts))
+	}
+}
+
+func TestAuditOptions_DisableCapture_NoOpts(t *testing.T) {
+	fa := false
+	cfg := config.AuditConfig{CapturePayloads: &fa}
+	opts := auditOptions(cfg)
+	if len(opts) != 0 {
+		t.Errorf("expected zero opts when capture disabled, got %d", len(opts))
+	}
+}
+
+func TestAuditOptions_DisableHeaders(t *testing.T) {
+	tr := true
+	fa := false
+	cfg := config.AuditConfig{
+		CapturePayloads: &tr,
+		CaptureHeaders:  &fa,
+	}
+	opts := auditOptions(cfg)
+	// Should have payload capture but NOT header capture; the option
+	// list length is the cheap proxy.
+	if len(opts) > 1 {
+		t.Errorf("with headers off, expected only payload opt(s), got %d", len(opts))
+	}
+}
+
+func TestAuditOptions_MaxNotificationsThreaded(t *testing.T) {
+	cfg := config.AuditConfig{MaxNotifications: 25}
+	opts := auditOptions(cfg)
+	// payload + header + notifications = 3 opts.
+	if len(opts) != 3 {
+		t.Errorf("expected 3 opts (payload + header + notifications), got %d", len(opts))
+	}
+}
+
+func TestAuditOptions_ZeroNotificationsOmitsOpt(t *testing.T) {
+	cfg := config.AuditConfig{MaxNotifications: 0}
+	opts := auditOptions(cfg)
+	// payload + header = 2; no notifications opt because zero means
+	// "use the middleware default".
+	if len(opts) != 2 {
+		t.Errorf("expected 2 opts (no notifications), got %d", len(opts))
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -166,6 +166,10 @@ func buildFromDeps(cfg *config.Config, logger *slog.Logger, chain *auth.Chain, a
 	mcpServer.AddReceivingMiddleware(
 		mcpmw.Audit(chain, auditLog, cfg.Audit.RedactKeys, registry.Groups(), auditOptions(cfg.Audit)...),
 	)
+	// Sending side: capture every notifications/* dispatched during a
+	// tool-call window so they land in audit_payloads.notifications.
+	// No-op when payload capture is off (the recorder isn't seeded).
+	mcpServer.AddSendingMiddleware(mcpmw.Notifications())
 
 	readiness := httpsrv.NewReadiness()
 	mux := buildMux(cfg, mcpServer, readiness)

--- a/pkg/audit/event.go
+++ b/pkg/audit/event.go
@@ -172,6 +172,11 @@ func (e *Event) WithPayload(p *Payload) *Event {
 // (case-insensitive substring match) appears in redactKeys replaced by
 // "[redacted]". Values inside arrays are recursed but array elements are not
 // keyed by name, so they are kept as-is.
+//
+// Fast path: when redactKeys is empty there's nothing to redact, so we
+// return the input map directly (same reference) instead of paying for a
+// deep copy. Callers that need a defensive copy should make one
+// themselves; this is a hot-path helper called once per audit row.
 func SanitizeParameters(v any, redactKeys []string) map[string]any {
 	if v == nil {
 		return nil
@@ -179,6 +184,9 @@ func SanitizeParameters(v any, redactKeys []string) map[string]any {
 	m, ok := v.(map[string]any)
 	if !ok {
 		return map[string]any{"_value": v}
+	}
+	if len(redactKeys) == 0 {
+		return m
 	}
 	out := make(map[string]any, len(m))
 	for k, val := range m {

--- a/pkg/audit/event.go
+++ b/pkg/audit/event.go
@@ -73,8 +73,11 @@ type Payload struct {
 	ResponseSizeBytes int            `json:"response_size_bytes,omitempty"`
 	ResponseTruncated bool           `json:"response_truncated,omitempty"`
 
-	// Notifications fired during the call window.
-	Notifications []Notification `json:"notifications,omitempty"`
+	// Notifications fired during the call window. NotificationsTruncated
+	// is set when the captured slice exceeded MaxPayloadBytes and the
+	// tail was dropped to fit; the surviving prefix is what's stored.
+	Notifications          []Notification `json:"notifications,omitempty"`
+	NotificationsTruncated bool           `json:"notifications_truncated,omitempty"`
 
 	// Replay linkage; if this event was a /replay of another, this
 	// points at the original event's ID.

--- a/pkg/audit/event.go
+++ b/pkg/audit/event.go
@@ -49,18 +49,22 @@ type Event struct {
 // by ID. Stored in the audit_payloads table. Each side carries a byte
 // size and a truncation flag so operators can tell whether they're
 // looking at the whole call or a capped prefix.
+//
+// Fields that the audit middleware can't populate today (the
+// transport-layer JSON-RPC ID, the inbound HTTP method and path) are
+// intentionally absent from this struct. They will land alongside a
+// transport-layer capture hook when replay-via-HTTP needs them.
 type Payload struct {
-	// JSON-RPC envelope as received.
+	// JSON-RPC method as the receiving middleware saw it (typically
+	// "tools/call"). Captured from the dispatch metadata, not the wire.
 	JSONRPCMethod    string         `json:"jsonrpc_method,omitempty"`
-	JSONRPCID        string         `json:"jsonrpc_id,omitempty"`
 	RequestParams    map[string]any `json:"request_params,omitempty"`
 	RequestSizeBytes int            `json:"request_size_bytes,omitempty"`
 	RequestTruncated bool           `json:"request_truncated,omitempty"`
 
-	// HTTP layer.
+	// HTTP layer (best-effort; only what the audit middleware can
+	// observe through ctx).
 	RequestHeaders    map[string][]string `json:"request_headers,omitempty"`
-	RequestMethod     string              `json:"request_method,omitempty"`
-	RequestPath       string              `json:"request_path,omitempty"`
 	RequestRemoteAddr string              `json:"request_remote_addr,omitempty"`
 
 	// JSON-RPC response.
@@ -152,7 +156,10 @@ func (e *Event) WithResult(success bool, errMsg string, durMS int64) *Event {
 }
 
 // WithPayload attaches a full request/response payload to the event.
-// Pass nil to clear; nil-or-zero Payload values are not persisted.
+// A non-nil pointer is persisted as a row in audit_payloads; pass nil
+// to clear (or to leave the event summary-only). The persistence layer
+// does not look at the Payload's field contents to decide whether to
+// write a row; if you don't want a payload row, pass nil.
 func (e *Event) WithPayload(p *Payload) *Event {
 	e.Payload = p
 	return e

--- a/pkg/audit/event_payload_test.go
+++ b/pkg/audit/event_payload_test.go
@@ -28,7 +28,6 @@ func TestEvent_WithPayload_Roundtrip(t *testing.T) {
 func TestPayload_JSONShape(t *testing.T) {
 	p := &Payload{
 		JSONRPCMethod:    "tools/call",
-		JSONRPCID:        "42",
 		RequestParams:    map[string]any{"k": "v"},
 		RequestSizeBytes: 12,
 		RequestTruncated: false,
@@ -51,9 +50,8 @@ func TestPayload_JSONShape(t *testing.T) {
 	if err := json.Unmarshal(b, &round); err != nil {
 		t.Fatal(err)
 	}
-	// Sanity: every top-level key we expect is there.
 	for _, k := range []string{
-		"jsonrpc_method", "jsonrpc_id",
+		"jsonrpc_method",
 		"request_params", "request_size_bytes",
 		"response_result", "response_size_bytes",
 		"notifications",

--- a/pkg/audit/postgres/store.go
+++ b/pkg/audit/postgres/store.go
@@ -127,14 +127,14 @@ func insertPayload(ctx context.Context, tx pgx.Tx, eventID string, p *audit.Payl
 			request_params, request_size_bytes, request_truncated,
 			request_headers, request_remote_addr,
 			response_result, response_error, response_size_bytes, response_truncated,
-			notifications, replayed_from
+			notifications, notifications_truncated, replayed_from
 		) VALUES (
 			$1,
 			$2,
 			$3, $4, $5,
 			$6, $7,
 			$8, $9, $10, $11,
-			$12, $13
+			$12, $13, $14
 		)
 	`,
 		eventID,
@@ -142,7 +142,7 @@ func insertPayload(ctx context.Context, tx pgx.Tx, eventID string, p *audit.Payl
 		requestParams, p.RequestSizeBytes, p.RequestTruncated,
 		requestHeaders, p.RequestRemoteAddr,
 		responseResult, responseError, p.ResponseSizeBytes, p.ResponseTruncated,
-		notifications, replayedFrom,
+		notifications, p.NotificationsTruncated, replayedFrom,
 	)
 	if err != nil {
 		return fmt.Errorf("insert audit payload: %w", err)
@@ -198,6 +198,7 @@ func (s *Store) GetPayload(ctx context.Context, eventID string) (*audit.Payload,
 			response_size_bytes,
 			response_truncated,
 			notifications,
+			notifications_truncated,
 			COALESCE(replayed_from, '')
 		FROM audit_payloads
 		WHERE event_id = $1
@@ -223,6 +224,7 @@ func (s *Store) GetPayload(ctx context.Context, eventID string) (*audit.Payload,
 		&p.ResponseSizeBytes,
 		&p.ResponseTruncated,
 		&notificationsB,
+		&p.NotificationsTruncated,
 		&p.ReplayedFrom,
 	)
 	if err != nil {

--- a/pkg/audit/postgres/store.go
+++ b/pkg/audit/postgres/store.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
+	"reflect"
 	"strings"
 	"time"
 
@@ -121,24 +123,24 @@ func insertPayload(ctx context.Context, tx pgx.Tx, eventID string, p *audit.Payl
 	_, err = tx.Exec(ctx, `
 		INSERT INTO audit_payloads (
 			event_id,
-			jsonrpc_method, jsonrpc_id,
+			jsonrpc_method,
 			request_params, request_size_bytes, request_truncated,
-			request_headers, request_method, request_path, request_remote_addr,
+			request_headers, request_remote_addr,
 			response_result, response_error, response_size_bytes, response_truncated,
 			notifications, replayed_from
 		) VALUES (
 			$1,
-			$2, $3,
-			$4, $5, $6,
-			$7, $8, $9, $10,
-			$11, $12, $13, $14,
-			$15, $16
+			$2,
+			$3, $4, $5,
+			$6, $7,
+			$8, $9, $10, $11,
+			$12, $13
 		)
 	`,
 		eventID,
-		p.JSONRPCMethod, p.JSONRPCID,
+		p.JSONRPCMethod,
 		requestParams, p.RequestSizeBytes, p.RequestTruncated,
-		requestHeaders, p.RequestMethod, p.RequestPath, p.RequestRemoteAddr,
+		requestHeaders, p.RequestRemoteAddr,
 		responseResult, responseError, p.ResponseSizeBytes, p.ResponseTruncated,
 		notifications, replayedFrom,
 	)
@@ -148,44 +150,48 @@ func insertPayload(ctx context.Context, tx pgx.Tx, eventID string, p *audit.Payl
 	return nil
 }
 
-// marshalJSONB returns the JSON encoding of v, or nil for nil/empty inputs
-// so the column stores SQL NULL (which is friendlier to JSONB queries
-// than a literal "null").
+// marshalJSONB returns the JSON encoding of v, or nil for nil-or-empty
+// inputs so the column stores SQL NULL (which is friendlier to JSONB
+// queries than a literal "null"). Empty-detection uses reflection so it
+// handles every map / slice / array type uniformly: no fragile type
+// switch to maintain as Payload grows.
 func marshalJSONB(v any) ([]byte, error) {
 	if v == nil {
 		return nil, nil
 	}
-	switch x := v.(type) {
-	case map[string]any:
-		if len(x) == 0 {
-			return nil, nil
-		}
-	case map[string][]string:
-		if len(x) == 0 {
-			return nil, nil
-		}
-	case []audit.Notification:
-		if len(x) == 0 {
-			return nil, nil
-		}
+	if isEmptyValue(v) {
+		return nil, nil
 	}
 	return json.Marshal(v)
 }
 
+// isEmptyValue reports whether v is the zero-length form of a
+// container type (map, slice, array, channel) or a nil pointer.
+// Anything else is considered non-empty.
+func isEmptyValue(v any) bool {
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Map, reflect.Slice, reflect.Array, reflect.Chan, reflect.String:
+		return rv.Len() == 0
+	case reflect.Pointer, reflect.Interface:
+		return rv.IsNil()
+	}
+	return false
+}
+
 // GetPayload returns the audit_payloads row for the given event, or
 // (nil, nil) if no payload was captured. Errors other than "no rows" are
-// returned.
+// returned. Per-column JSON unmarshal failures (corrupt JSONB) are
+// logged at WARN and the field stays empty so the rest of the payload
+// can still render.
 func (s *Store) GetPayload(ctx context.Context, eventID string) (*audit.Payload, error) {
 	row := s.pool.QueryRow(ctx, `
 		SELECT
 			COALESCE(jsonrpc_method, ''),
-			COALESCE(jsonrpc_id, ''),
 			request_params,
 			request_size_bytes,
 			request_truncated,
 			request_headers,
-			COALESCE(request_method, ''),
-			COALESCE(request_path, ''),
 			COALESCE(request_remote_addr, ''),
 			response_result,
 			response_error,
@@ -207,13 +213,10 @@ func (s *Store) GetPayload(ctx context.Context, eventID string) (*audit.Payload,
 	)
 	err := row.Scan(
 		&p.JSONRPCMethod,
-		&p.JSONRPCID,
 		&paramsB,
 		&p.RequestSizeBytes,
 		&p.RequestTruncated,
 		&headersB,
-		&p.RequestMethod,
-		&p.RequestPath,
 		&p.RequestRemoteAddr,
 		&resultB,
 		&errB,
@@ -228,22 +231,30 @@ func (s *Store) GetPayload(ctx context.Context, eventID string) (*audit.Payload,
 		}
 		return nil, err
 	}
-	if len(paramsB) > 0 {
-		_ = json.Unmarshal(paramsB, &p.RequestParams)
-	}
-	if len(headersB) > 0 {
-		_ = json.Unmarshal(headersB, &p.RequestHeaders)
-	}
-	if len(resultB) > 0 {
-		_ = json.Unmarshal(resultB, &p.ResponseResult)
-	}
-	if len(errB) > 0 {
-		_ = json.Unmarshal(errB, &p.ResponseError)
-	}
-	if len(notificationsB) > 0 {
-		_ = json.Unmarshal(notificationsB, &p.Notifications)
-	}
+	unmarshalCol(eventID, "request_params", paramsB, &p.RequestParams)
+	unmarshalCol(eventID, "request_headers", headersB, &p.RequestHeaders)
+	unmarshalCol(eventID, "response_result", resultB, &p.ResponseResult)
+	unmarshalCol(eventID, "response_error", errB, &p.ResponseError)
+	unmarshalCol(eventID, "notifications", notificationsB, &p.Notifications)
 	return &p, nil
+}
+
+// unmarshalCol decodes a JSONB column into dest. Empty input is a no-op.
+// Decode failures (corrupt JSONB written by a buggy older binary) are
+// logged at WARN with the event ID + column name so operators can spot
+// them; the field stays empty so the rest of the payload still renders.
+func unmarshalCol(eventID, column string, data []byte, dest any) {
+	if len(data) == 0 {
+		return
+	}
+	if err := json.Unmarshal(data, dest); err != nil {
+		slog.Warn("audit: corrupt JSONB column",
+			"event_id", eventID,
+			"column", column,
+			"err", err,
+			"bytes", len(data),
+		)
+	}
 }
 
 // Query returns matching events. ORDER is by ts DESC unless f.OrderDesc is false.

--- a/pkg/audit/postgres/store_test.go
+++ b/pkg/audit/postgres/store_test.go
@@ -76,6 +76,7 @@ func TestStore_LogPayload_RoundtripAndCascade(t *testing.T) {
 					Params:    map[string]any{"step": 1, "total": 5},
 				},
 			},
+			NotificationsTruncated: true,
 		},
 	}
 	if err := store.Log(ctx, ev); err != nil {
@@ -110,6 +111,9 @@ func TestStore_LogPayload_RoundtripAndCascade(t *testing.T) {
 	}
 	if len(got.Notifications) != 1 || got.Notifications[0].Method != "notifications/progress" {
 		t.Errorf("notifications lost: %+v", got.Notifications)
+	}
+	if !got.NotificationsTruncated {
+		t.Errorf("NotificationsTruncated lost: got false, want true")
 	}
 
 	// Cascade: deleting the audit_events row should drop the payload.

--- a/pkg/audit/postgres/store_test.go
+++ b/pkg/audit/postgres/store_test.go
@@ -1,0 +1,220 @@
+//go:build integration
+
+// Behavioral tests for the Postgres-backed audit store. Tagged
+// `integration` so they only run with `go test -tags=integration`;
+// they require Docker to spin up the testcontainers Postgres.
+//
+// These cover the parts of the store that the unit suite can't:
+// the actual transactional two-row write, FK cascade behavior, the
+// JSONB round-trip through real columns, and the truncation flag
+// semantics observed end-to-end.
+package auditpg_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/plexara/mcp-test/pkg/audit"
+	auditpg "github.com/plexara/mcp-test/pkg/audit/postgres"
+	"github.com/plexara/mcp-test/pkg/database/migrate"
+)
+
+func TestStore_LogPayload_RoundtripAndCascade(t *testing.T) {
+	ctx := context.Background()
+	url := startPostgres(ctx, t)
+	if err := migrate.Up(url); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	pool, err := pgxpool.New(ctx, url)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	store := auditpg.New(pool)
+
+	// Write an event with a payload. Uses every captured column so
+	// the JSONB round-trip is exercised end-to-end.
+	ev := audit.Event{
+		ID:        "evt-1",
+		Timestamp: time.Now().UTC(),
+		ToolName:  "echo",
+		Transport: "http",
+		Source:    "mcp",
+		Success:   true,
+		Payload: &audit.Payload{
+			JSONRPCMethod: "tools/call",
+			RequestParams: map[string]any{
+				"message": "hello",
+				"nested":  map[string]any{"k": "v"},
+			},
+			RequestSizeBytes: 42,
+			RequestHeaders: map[string][]string{
+				"User-Agent": {"test"},
+				"X-Trace":    {"abc"},
+			},
+			RequestRemoteAddr: "10.0.0.1",
+			ResponseResult: map[string]any{
+				"isError": false,
+				"content": []any{
+					map[string]any{"type": "text", "text": "world"},
+				},
+			},
+			ResponseSizeBytes: 73,
+			Notifications: []audit.Notification{
+				{
+					Timestamp: time.Now().UTC(),
+					Method:    "notifications/progress",
+					Params:    map[string]any{"step": 1, "total": 5},
+				},
+			},
+		},
+	}
+	if err := store.Log(ctx, ev); err != nil {
+		t.Fatalf("Log: %v", err)
+	}
+
+	// Read it back.
+	got, err := store.GetPayload(ctx, "evt-1")
+	if err != nil {
+		t.Fatalf("GetPayload: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected payload, got nil")
+	}
+	if got.JSONRPCMethod != "tools/call" {
+		t.Errorf("JSONRPCMethod = %q", got.JSONRPCMethod)
+	}
+	if got.RequestParams["message"] != "hello" {
+		t.Errorf("request params lost: %+v", got.RequestParams)
+	}
+	if nested, _ := got.RequestParams["nested"].(map[string]any); nested == nil || nested["k"] != "v" {
+		t.Errorf("nested params lost: %+v", got.RequestParams)
+	}
+	if ua := got.RequestHeaders["User-Agent"]; len(ua) != 1 || ua[0] != "test" {
+		t.Errorf("headers lost: %+v", got.RequestHeaders)
+	}
+	if got.RequestRemoteAddr != "10.0.0.1" {
+		t.Errorf("remote_addr lost: %q", got.RequestRemoteAddr)
+	}
+	if isErr, _ := got.ResponseResult["isError"].(bool); isErr {
+		t.Errorf("response isError flipped to true")
+	}
+	if len(got.Notifications) != 1 || got.Notifications[0].Method != "notifications/progress" {
+		t.Errorf("notifications lost: %+v", got.Notifications)
+	}
+
+	// Cascade: deleting the audit_events row should drop the payload.
+	if _, err := pool.Exec(ctx, `DELETE FROM audit_events WHERE id = $1`, "evt-1"); err != nil {
+		t.Fatalf("delete event: %v", err)
+	}
+	got, err = store.GetPayload(ctx, "evt-1")
+	if err != nil {
+		t.Fatalf("GetPayload after delete: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil payload after cascade delete, got: %+v", got)
+	}
+}
+
+func TestStore_Log_NilPayloadOnlyWritesSummary(t *testing.T) {
+	ctx := context.Background()
+	url := startPostgres(ctx, t)
+	if err := migrate.Up(url); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := pgxpool.New(ctx, url)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	store := auditpg.New(pool)
+
+	ev := audit.Event{
+		ID:        "evt-2",
+		Timestamp: time.Now().UTC(),
+		ToolName:  "summary-only",
+		Transport: "http",
+		Source:    "mcp",
+		Success:   true,
+		// No Payload.
+	}
+	if err := store.Log(ctx, ev); err != nil {
+		t.Fatalf("Log: %v", err)
+	}
+	got, err := store.GetPayload(ctx, "evt-2")
+	if err != nil {
+		t.Fatalf("GetPayload: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil payload, got: %+v", got)
+	}
+
+	// Confirm the summary row IS present.
+	var n int
+	_ = pool.QueryRow(ctx, `SELECT count(*) FROM audit_events WHERE id = $1`, "evt-2").Scan(&n)
+	if n != 1 {
+		t.Errorf("summary row count = %d, want 1", n)
+	}
+}
+
+func TestStore_GetPayload_NotFound(t *testing.T) {
+	ctx := context.Background()
+	url := startPostgres(ctx, t)
+	if err := migrate.Up(url); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := pgxpool.New(ctx, url)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	store := auditpg.New(pool)
+
+	got, err := store.GetPayload(ctx, "no-such-event")
+	if err != nil {
+		t.Errorf("GetPayload err on missing = %v, want nil", err)
+	}
+	if got != nil {
+		t.Errorf("GetPayload on missing = %+v, want nil", got)
+	}
+}
+
+// startPostgres spins up a fresh Postgres 16-alpine container per test.
+// Mirrors tests/integration_test.go so we don't share fixtures across
+// packages that have different lifetimes.
+func startPostgres(ctx context.Context, t *testing.T) string {
+	t.Helper()
+	if os.Getenv("DOCKER_HOST") == "" && os.Getenv("HOME") == "" {
+		t.Skip("no docker socket discoverable")
+	}
+	pgC, err := tcpostgres.Run(ctx,
+		"postgres:16-alpine",
+		tcpostgres.WithDatabase("mcp_test"),
+		tcpostgres.WithUsername("mcp"),
+		tcpostgres.WithPassword("mcp"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second),
+		),
+	)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	t.Cleanup(func() { _ = pgC.Terminate(context.Background()) })
+
+	url, err := pgC.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("conn string: %v", err)
+	}
+	return url
+}

--- a/pkg/database/migrate/migrations/0002_audit_payloads.up.sql
+++ b/pkg/database/migrate/migrations/0002_audit_payloads.up.sql
@@ -10,32 +10,34 @@
 CREATE TABLE IF NOT EXISTS audit_payloads (
     event_id              TEXT PRIMARY KEY REFERENCES audit_events(id) ON DELETE CASCADE,
 
-    -- JSON-RPC envelope as received
+    -- JSON-RPC envelope as received. Only what the audit middleware can
+    -- observe today: the dispatched method and the params object.
     jsonrpc_method        TEXT,
-    jsonrpc_id            TEXT,
     request_params        JSONB,
     request_size_bytes    INTEGER NOT NULL DEFAULT 0,
     request_truncated     BOOLEAN NOT NULL DEFAULT false,
 
-    -- HTTP layer
+    -- HTTP layer (best-effort; only what the audit middleware can read
+    -- from ctx).
     request_headers       JSONB,
-    request_method        TEXT,
-    request_path          TEXT,
     request_remote_addr   TEXT,
 
-    -- JSON-RPC response
+    -- JSON-RPC response.
     response_result       JSONB,
     response_error        JSONB,
     response_size_bytes   INTEGER NOT NULL DEFAULT 0,
     response_truncated    BOOLEAN NOT NULL DEFAULT false,
 
-    -- Notifications fired during the call window: array of {ts, method, params}
+    -- Notifications fired during the call window: array of {ts, method, params}.
     notifications         JSONB,
 
     -- Replay linkage; ON DELETE SET NULL so deleting the original doesn't
     -- cascade into the replay's payload row.
     replayed_from         TEXT REFERENCES audit_events(id) ON DELETE SET NULL,
 
+    -- captured_at supports forensic queries ("payloads written between
+    -- t1 and t2") that the call's own audit_events.ts can't answer when
+    -- the audit pipeline is delayed (async drain backlog).
     captured_at           TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 

--- a/pkg/database/migrate/migrations/0002_audit_payloads.up.sql
+++ b/pkg/database/migrate/migrations/0002_audit_payloads.up.sql
@@ -29,7 +29,10 @@ CREATE TABLE IF NOT EXISTS audit_payloads (
     response_truncated    BOOLEAN NOT NULL DEFAULT false,
 
     -- Notifications fired during the call window: array of {ts, method, params}.
-    notifications         JSONB,
+    -- notifications_truncated is set when the captured slice was trimmed
+    -- to fit max_payload_bytes; the prefix is what's stored.
+    notifications            JSONB,
+    notifications_truncated  BOOLEAN NOT NULL DEFAULT false,
 
     -- Replay linkage; ON DELETE SET NULL so deleting the original doesn't
     -- cascade into the replay's payload row.

--- a/pkg/database/migrate/migrations/0002_audit_payloads.up.sql
+++ b/pkg/database/migrate/migrations/0002_audit_payloads.up.sql
@@ -10,37 +10,32 @@
 CREATE TABLE IF NOT EXISTS audit_payloads (
     event_id              TEXT PRIMARY KEY REFERENCES audit_events(id) ON DELETE CASCADE,
 
-    -- JSON-RPC envelope as received. Only what the audit middleware can
-    -- observe today: the dispatched method and the params object.
+    -- JSON-RPC envelope as received
     jsonrpc_method        TEXT,
+    jsonrpc_id            TEXT,
     request_params        JSONB,
     request_size_bytes    INTEGER NOT NULL DEFAULT 0,
     request_truncated     BOOLEAN NOT NULL DEFAULT false,
 
-    -- HTTP layer (best-effort; only what the audit middleware can read
-    -- from ctx).
+    -- HTTP layer
     request_headers       JSONB,
+    request_method        TEXT,
+    request_path          TEXT,
     request_remote_addr   TEXT,
 
-    -- JSON-RPC response.
+    -- JSON-RPC response
     response_result       JSONB,
     response_error        JSONB,
     response_size_bytes   INTEGER NOT NULL DEFAULT 0,
     response_truncated    BOOLEAN NOT NULL DEFAULT false,
 
-    -- Notifications fired during the call window: array of {ts, method, params}.
-    -- notifications_truncated is set when the captured slice was trimmed
-    -- to fit max_payload_bytes; the prefix is what's stored.
-    notifications            JSONB,
-    notifications_truncated  BOOLEAN NOT NULL DEFAULT false,
+    -- Notifications fired during the call window: array of {ts, method, params}
+    notifications         JSONB,
 
     -- Replay linkage; ON DELETE SET NULL so deleting the original doesn't
     -- cascade into the replay's payload row.
     replayed_from         TEXT REFERENCES audit_events(id) ON DELETE SET NULL,
 
-    -- captured_at supports forensic queries ("payloads written between
-    -- t1 and t2") that the call's own audit_events.ts can't answer when
-    -- the audit pipeline is delayed (async drain backlog).
     captured_at           TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 

--- a/pkg/database/migrate/migrations/0003_audit_payloads_cleanup.down.sql
+++ b/pkg/database/migrate/migrations/0003_audit_payloads_cleanup.down.sql
@@ -1,0 +1,11 @@
+-- Reverse of 0003_audit_payloads_cleanup.up.sql.
+--
+-- Down migration is best-effort: the historical 0002 columns we drop
+-- here can be re-created, but their original data is gone the moment
+-- the .up ran, so this is purely structural restore.
+
+ALTER TABLE audit_payloads DROP COLUMN IF EXISTS notifications_truncated;
+
+ALTER TABLE audit_payloads ADD COLUMN IF NOT EXISTS jsonrpc_id     TEXT;
+ALTER TABLE audit_payloads ADD COLUMN IF NOT EXISTS request_method TEXT;
+ALTER TABLE audit_payloads ADD COLUMN IF NOT EXISTS request_path   TEXT;

--- a/pkg/database/migrate/migrations/0003_audit_payloads_cleanup.up.sql
+++ b/pkg/database/migrate/migrations/0003_audit_payloads_cleanup.up.sql
@@ -1,0 +1,18 @@
+-- Cleanup of audit_payloads following PR #5 review.
+--
+-- 0002 shipped in v1.1.0 with three columns the audit middleware never
+-- learned to populate (jsonrpc_id, request_method, request_path) plus a
+-- missing flag for notification trimming. This migration realigns the
+-- table with the current store: drops the three unused columns, adds
+-- notifications_truncated.
+--
+-- All ALTERs use IF EXISTS / IF NOT EXISTS so re-running on a database
+-- that already saw 0003 is a no-op, and on a database that skipped
+-- straight to v1.1.x then upgraded mid-cycle still lands consistently.
+
+ALTER TABLE audit_payloads DROP COLUMN IF EXISTS jsonrpc_id;
+ALTER TABLE audit_payloads DROP COLUMN IF EXISTS request_method;
+ALTER TABLE audit_payloads DROP COLUMN IF EXISTS request_path;
+
+ALTER TABLE audit_payloads
+    ADD COLUMN IF NOT EXISTS notifications_truncated BOOLEAN NOT NULL DEFAULT false;

--- a/pkg/httpsrv/portal_api.go
+++ b/pkg/httpsrv/portal_api.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/plexara/mcp-test/pkg/audit"
 	"github.com/plexara/mcp-test/pkg/auth"
 	"github.com/plexara/mcp-test/pkg/build"
@@ -175,11 +177,21 @@ func (p *PortalAPI) auditEvents(w http.ResponseWriter, r *http.Request) {
 // Response shape mirrors the Event JSON marshaling; when payload was
 // captured, it appears under the "payload" key.
 func (p *PortalAPI) auditEventDetail(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
-	if id == "" {
+	rawID := r.PathValue("id")
+	if rawID == "" {
 		writeError(w, http.StatusBadRequest, fmt.Errorf("event id required"))
 		return
 	}
+	// Audit event IDs are UUIDs minted by NewEvent. Reject anything else
+	// at the boundary; we then log only the canonicalized uuid.String()
+	// rather than the raw path value so gosec's taint analysis can see
+	// the user-controlled string is no longer in the slog.Warn path.
+	parsed, err := uuid.Parse(rawID)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("event id is not a valid uuid"))
+		return
+	}
+	id := parsed.String()
 
 	// The Logger interface doesn't expose a typed single-event lookup;
 	// reuse Query with EventID set and Limit:1. The Postgres store
@@ -207,10 +219,10 @@ func (p *PortalAPI) auditEventDetail(w http.ResponseWriter, r *http.Request) {
 			// Soft-fail: the summary is real, only the detail is
 			// unavailable. Log at WARN with the event ID so operators
 			// can chase the cause without the request itself failing.
-			slog.Warn("audit: payload fetch failed",
-				"event_id", id,
-				"err", perr,
-			)
+			// id is a canonical uuid.UUID.String() form (validated
+			// above); gosec's transitive taint propagation flags this
+			// regardless, so #nosec is correct here.
+			slog.Warn("audit: payload fetch failed", "event_id", id, "err", perr) // #nosec G706 -- id is a validated, canonicalized UUID; cannot carry log-injection bytes.
 		} else {
 			ev.Payload = payload
 		}

--- a/pkg/httpsrv/portal_api.go
+++ b/pkg/httpsrv/portal_api.go
@@ -3,6 +3,7 @@ package httpsrv
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -180,10 +181,10 @@ func (p *PortalAPI) auditEventDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// The Logger interface doesn't have a single-event lookup; reuse Query
-	// with a bounded filter and pluck the matching row. This is O(scan)
-	// today; if event detail becomes a hot path we can add a primary-key
-	// fetch to the interface.
+	// The Logger interface doesn't expose a typed single-event lookup;
+	// reuse Query with EventID set and Limit:1. The Postgres store
+	// resolves this to a primary-key index lookup; the in-memory logger
+	// scans its slice (fine for tests).
 	events, err := p.audit.Query(r.Context(), audit.QueryFilter{Limit: 1, EventID: id})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err)
@@ -202,11 +203,17 @@ func (p *PortalAPI) auditEventDetail(w http.ResponseWriter, r *http.Request) {
 	ev.Payload = nil
 	if pl, ok := p.audit.(audit.PayloadLogger); ok {
 		payload, perr := pl.GetPayload(r.Context(), id)
-		if perr == nil {
+		if perr != nil {
+			// Soft-fail: the summary is real, only the detail is
+			// unavailable. Log at WARN with the event ID so operators
+			// can chase the cause without the request itself failing.
+			slog.Warn("audit: payload fetch failed",
+				"event_id", id,
+				"err", perr,
+			)
+		} else {
 			ev.Payload = payload
 		}
-		// Soft-fail on perr: the summary is real, only detail is
-		// unavailable; the binary's logs carry the error.
 	}
 
 	writeJSON(w, http.StatusOK, ev)

--- a/pkg/httpsrv/portal_api_detail_test.go
+++ b/pkg/httpsrv/portal_api_detail_test.go
@@ -10,10 +10,20 @@ import (
 	"github.com/plexara/mcp-test/pkg/audit"
 )
 
+// Real audit IDs are UUIDs (audit.NewEvent stamps uuid.NewString()), and
+// the detail endpoint validates the path param to block the gosec G706
+// log-injection flow. These tests use literal UUIDs so they exercise the
+// same path operators hit.
+const (
+	testEventIDFound  = "11111111-1111-1111-1111-111111111111"
+	testEventIDOther  = "22222222-2222-2222-2222-222222222222"
+	testEventIDAbsent = "33333333-3333-3333-3333-333333333333"
+)
+
 func TestPortalAPI_AuditEventDetail_Found(t *testing.T) {
 	mem := audit.NewMemoryLogger()
 	ev := audit.Event{
-		ID:        "evt-123",
+		ID:        testEventIDFound,
 		ToolName:  "echo",
 		Success:   true,
 		Transport: "http",
@@ -23,13 +33,13 @@ func TestPortalAPI_AuditEventDetail_Found(t *testing.T) {
 
 	mux := portalTestMux(t, mem)
 	w := httptest.NewRecorder()
-	mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/portal/audit/events/evt-123", nil))
+	mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/portal/audit/events/"+testEventIDFound, nil))
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
 	}
 	var got map[string]any
 	_ = json.NewDecoder(w.Body).Decode(&got)
-	if got["id"] != "evt-123" {
+	if got["id"] != testEventIDFound {
 		t.Errorf("id = %v", got["id"])
 	}
 	if got["tool_name"] != "echo" {
@@ -40,16 +50,27 @@ func TestPortalAPI_AuditEventDetail_Found(t *testing.T) {
 func TestPortalAPI_AuditEventDetail_NotFound(t *testing.T) {
 	mux := portalTestMux(t, audit.NewMemoryLogger())
 	w := httptest.NewRecorder()
-	mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/portal/audit/events/missing", nil))
+	mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/portal/audit/events/"+testEventIDAbsent, nil))
 	if w.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestPortalAPI_AuditEventDetail_RejectsNonUUID(t *testing.T) {
+	// New: the detail endpoint validates the path param as a UUID
+	// before any DB work or logging. Anything else is a 400.
+	mux := portalTestMux(t, audit.NewMemoryLogger())
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/portal/audit/events/not-a-uuid", nil))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
 	}
 }
 
 func TestPortalAPI_AuditEventDetail_PayloadAbsentForMemoryLogger(t *testing.T) {
 	mem := audit.NewMemoryLogger()
 	ev := audit.Event{
-		ID:        "evt-456",
+		ID:        testEventIDOther,
 		ToolName:  "echo",
 		Transport: "http",
 		Source:    "mcp",
@@ -61,7 +82,7 @@ func TestPortalAPI_AuditEventDetail_PayloadAbsentForMemoryLogger(t *testing.T) {
 
 	mux := portalTestMux(t, mem)
 	w := httptest.NewRecorder()
-	mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/portal/audit/events/evt-456", nil))
+	mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/portal/audit/events/"+testEventIDOther, nil))
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d", w.Code)
 	}

--- a/pkg/mcpmw/audit.go
+++ b/pkg/mcpmw/audit.go
@@ -136,6 +136,18 @@ func Audit(chain *auth.Chain, logger audit.Logger, redactKeys []string, toolGrou
 
 			ev.WithParameters(audit.SanitizeParameters(params, redactKeys))
 
+			// Seed a notification recorder onto ctx if payload capture is
+			// on. The Notifications() sending middleware reads this off
+			// ctx and appends as the tool fires NotifyProgress / Log /
+			// other notifications/* methods. Always create when capture
+			// is enabled so a payload row exists with an empty
+			// notifications array rather than absent.
+			var recorder *notificationRecorder
+			if o.capturePayloads {
+				recorder = newNotificationRecorder(o.maxNotifications)
+				ctx = withRecorder(ctx, recorder)
+			}
+
 			res, err := next(ctx, method, req)
 			ev.WithResult(err == nil, errString(err), time.Since(start).Milliseconds())
 			var cr *mcp.CallToolResult
@@ -150,11 +162,11 @@ func Audit(chain *auth.Chain, logger audit.Logger, redactKeys []string, toolGrou
 					errCategory = "tool"
 				}
 			}
-			if err != nil {
+			if errCategory == "" && err != nil {
 				errCategory = "handler"
 			}
 			if o.capturePayloads {
-				ev.WithPayload(buildPayload(ctx, method, params, redactKeys, cr, err, errCategory, o, nil))
+				ev.WithPayload(buildPayload(ctx, method, params, redactKeys, cr, err, errCategory, o, recorder.Snapshot()))
 			}
 			_ = logger.Log(ctx, *ev)
 			return res, err

--- a/pkg/mcpmw/audit.go
+++ b/pkg/mcpmw/audit.go
@@ -139,12 +139,13 @@ func Audit(chain *auth.Chain, logger audit.Logger, redactKeys []string, toolGrou
 			// Seed a notification recorder onto ctx if payload capture is
 			// on. The Notifications() sending middleware reads this off
 			// ctx and appends as the tool fires NotifyProgress / Log /
-			// other notifications/* methods. Always create when capture
-			// is enabled so a payload row exists with an empty
-			// notifications array rather than absent.
+			// other notifications/* methods. The recorder applies the
+			// same redactKeys as the rest of the audit pipeline, so a
+			// tool that emits a sensitive value through NotifyProgress
+			// or LogMessage cannot bypass the operator's redact list.
 			var recorder *notificationRecorder
 			if o.capturePayloads {
-				recorder = newNotificationRecorder(o.maxNotifications)
+				recorder = newNotificationRecorder(o.maxNotifications, redactKeys)
 				ctx = withRecorder(ctx, recorder)
 			}
 
@@ -158,13 +159,13 @@ func Audit(chain *auth.Chain, logger audit.Logger, redactKeys []string, toolGrou
 				ev.WithResponseSize(chars, blocks)
 				if cr.IsError && err == nil {
 					ev.Success = false
-					ev.ErrorCategory = "tool"
 					errCategory = "tool"
 				}
 			}
 			if errCategory == "" && err != nil {
 				errCategory = "handler"
 			}
+			ev.ErrorCategory = errCategory
 			if o.capturePayloads {
 				ev.WithPayload(buildPayload(ctx, method, params, redactKeys, cr, err, errCategory, o, recorder.Snapshot()))
 			}
@@ -253,16 +254,41 @@ func buildPayload(
 		p.ResponseError = errPayload
 	}
 
-	// Notifications captured by the recorder, capped per opts.
+	// Notifications: the recorder already capped count at Append time.
+	// Apply a byte cap here too: a LogMessage carries an arbitrary
+	// `data any` blob, so a small count of notifications can still
+	// exceed maxPayloadBytes. Trim from the tail until the slice fits;
+	// flag truncation if anything was dropped.
 	if len(notifications) > 0 {
-		max := opts.maxNotifications
-		if max > 0 && len(notifications) > max {
-			notifications = notifications[:max]
-		}
+		notifications, p.NotificationsTruncated = fitNotifications(notifications, opts.maxPayloadBytes)
 		p.Notifications = notifications
 	}
 
 	return p
+}
+
+// fitNotifications trims trailing entries until the slice's JSON encoding
+// fits in max bytes. Returns the surviving prefix and whether anything
+// was dropped. A non-positive max means "no limit". An empty input is a
+// pass-through.
+func fitNotifications(in []audit.Notification, max int) ([]audit.Notification, bool) {
+	if len(in) == 0 || max <= 0 {
+		return in, false
+	}
+	if _, ok := jsonSizeWithin(in, max); ok {
+		return in, false
+	}
+	// Binary search for the longest prefix that fits, then return it.
+	lo, hi := 0, len(in)
+	for lo < hi {
+		mid := (lo + hi + 1) / 2
+		if _, ok := jsonSizeWithin(in[:mid], max); ok {
+			lo = mid
+		} else {
+			hi = mid - 1
+		}
+	}
+	return in[:lo], true
 }
 
 // callToolResultToMap renders a CallToolResult in the same shape the
@@ -315,24 +341,30 @@ func callToolResultToMap(cr *mcp.CallToolResult) map[string]any {
 // "type" tag, so the resulting map is the same thing a peer client
 // would receive. If marshal fails (it shouldn't for SDK types), we
 // surface the failure rather than dropping the block.
+//
+// Sentinel "type" values distinguish the three failure modes so the
+// portal can render them differently and operators can grep for them:
+//   - "_marshal_error": the SDK content's MarshalJSON returned an error
+//   - "_unmarshal_error": marshal succeeded but the bytes weren't an object
+//   - "_no_type": the SDK marshaled the content without a "type" field
 func contentToGenericMap(c mcp.Content) map[string]any {
 	b, err := json.Marshal(c)
 	if err != nil {
 		return map[string]any{
-			"type":         "unknown",
-			"marshalError": err.Error(),
+			"type":          "_marshal_error",
+			"marshal_error": err.Error(),
 		}
 	}
 	var m map[string]any
 	if err := json.Unmarshal(b, &m); err != nil {
 		return map[string]any{
-			"type":           "unknown",
-			"unmarshalError": err.Error(),
-			"raw":            string(b),
+			"type":            "_unmarshal_error",
+			"unmarshal_error": err.Error(),
+			"raw":             string(b),
 		}
 	}
 	if _, hasType := m["type"]; !hasType {
-		m["type"] = "unknown"
+		m["type"] = "_no_type"
 	}
 	return m
 }

--- a/pkg/mcpmw/audit.go
+++ b/pkg/mcpmw/audit.go
@@ -128,7 +128,7 @@ func Audit(chain *auth.Chain, logger audit.Logger, redactKeys []string, toolGrou
 				ev.WithResult(false, authErr.Error(), time.Since(start).Milliseconds())
 				ev.ErrorCategory = "auth"
 				if o.capturePayloads {
-					ev.WithPayload(buildPayload(ctx, req, params, redactKeys, nil, authErr, o, nil))
+					ev.WithPayload(buildPayload(ctx, method, params, redactKeys, nil, authErr, "auth", o, nil))
 				}
 				_ = logger.Log(ctx, *ev)
 				return nil, authErr
@@ -139,6 +139,7 @@ func Audit(chain *auth.Chain, logger audit.Logger, redactKeys []string, toolGrou
 			res, err := next(ctx, method, req)
 			ev.WithResult(err == nil, errString(err), time.Since(start).Milliseconds())
 			var cr *mcp.CallToolResult
+			errCategory := ""
 			if r, ok := res.(*mcp.CallToolResult); ok && r != nil {
 				cr = r
 				chars, blocks := measureResult(cr)
@@ -146,10 +147,14 @@ func Audit(chain *auth.Chain, logger audit.Logger, redactKeys []string, toolGrou
 				if cr.IsError && err == nil {
 					ev.Success = false
 					ev.ErrorCategory = "tool"
+					errCategory = "tool"
 				}
 			}
+			if err != nil {
+				errCategory = "handler"
+			}
 			if o.capturePayloads {
-				ev.WithPayload(buildPayload(ctx, req, params, redactKeys, cr, err, o, nil))
+				ev.WithPayload(buildPayload(ctx, method, params, redactKeys, cr, err, errCategory, o, nil))
 			}
 			_ = logger.Log(ctx, *ev)
 			return res, err
@@ -158,6 +163,10 @@ func Audit(chain *auth.Chain, logger audit.Logger, redactKeys []string, toolGrou
 }
 
 // buildPayload assembles the full audit_payloads row for one tools/call.
+// errCategory is "auth", "tool", "handler", or "" for success and is
+// stored on the response_error blob so the portal can filter without
+// string-matching against the message.
+//
 // The notifications slice is captured by the caller via a session
 // recorder (see notification.go); pass nil when no recording was wired.
 //
@@ -168,16 +177,17 @@ func Audit(chain *auth.Chain, logger audit.Logger, redactKeys []string, toolGrou
 // HeaderCapture middleware).
 func buildPayload(
 	ctx context.Context,
-	_ mcp.Request,
+	method string,
 	rawParams map[string]any,
 	redactKeys []string,
 	cr *mcp.CallToolResult,
 	callErr error,
+	errCategory string,
 	opts auditOptions,
 	notifications []audit.Notification,
 ) *audit.Payload {
 	p := &audit.Payload{
-		JSONRPCMethod:     "tools/call",
+		JSONRPCMethod:     method,
 		RequestRemoteAddr: auth.GetRemoteAddr(ctx),
 	}
 
@@ -218,11 +228,17 @@ func buildPayload(
 	}
 
 	// Errors land in response_error so the portal can render them
-	// distinct from a tool that returned IsError=true.
+	// distinct from a tool that returned IsError=true. category lets
+	// the portal filter ("show me only auth rejects") without string-
+	// matching against the message.
 	if callErr != nil {
-		p.ResponseError = map[string]any{
+		errPayload := map[string]any{
 			"message": callErr.Error(),
 		}
+		if errCategory != "" {
+			errPayload["category"] = errCategory
+		}
+		p.ResponseError = errPayload
 	}
 
 	// Notifications captured by the recorder, capped per opts.
@@ -240,6 +256,13 @@ func buildPayload(
 // callToolResultToMap renders a CallToolResult in the same shape the
 // MCP SDK serializes to the wire, so portal consumers can iterate
 // content blocks by type without reflection on Go-only types.
+//
+// Known content types (text/image/audio) are projected into a flat
+// {type, ...} map. Anything else falls through to a JSON round-trip via
+// the type's own MarshalJSON; the resulting map is preserved verbatim
+// (with a defensive type tag injected if the marshal didn't carry one)
+// so resource content, embedded resources, and any future content
+// kinds are still inspectable in the portal.
 func callToolResultToMap(cr *mcp.CallToolResult) map[string]any {
 	out := map[string]any{
 		"isError": cr.IsError,
@@ -265,10 +288,7 @@ func callToolResultToMap(cr *mcp.CallToolResult) map[string]any {
 				"data":     v.Data,
 			})
 		default:
-			blocks = append(blocks, map[string]any{
-				"type":  "unknown",
-				"shape": "non-textual content block",
-			})
+			blocks = append(blocks, contentToGenericMap(c))
 		}
 	}
 	out["content"] = blocks
@@ -276,6 +296,33 @@ func callToolResultToMap(cr *mcp.CallToolResult) map[string]any {
 		out["structuredContent"] = cr.StructuredContent
 	}
 	return out
+}
+
+// contentToGenericMap round-trips a content block through JSON. The MCP
+// SDK's content types implement json.Marshaler with the wire-shape
+// "type" tag, so the resulting map is the same thing a peer client
+// would receive. If marshal fails (it shouldn't for SDK types), we
+// surface the failure rather than dropping the block.
+func contentToGenericMap(c mcp.Content) map[string]any {
+	b, err := json.Marshal(c)
+	if err != nil {
+		return map[string]any{
+			"type":         "unknown",
+			"marshalError": err.Error(),
+		}
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		return map[string]any{
+			"type":           "unknown",
+			"unmarshalError": err.Error(),
+			"raw":            string(b),
+		}
+	}
+	if _, hasType := m["type"]; !hasType {
+		m["type"] = "unknown"
+	}
+	return m
 }
 
 // jsonSizeWithin reports the JSON byte size of v and whether it falls

--- a/pkg/mcpmw/audit.go
+++ b/pkg/mcpmw/audit.go
@@ -271,24 +271,35 @@ func buildPayload(
 // fits in max bytes. Returns the surviving prefix and whether anything
 // was dropped. A non-positive max means "no limit". An empty input is a
 // pass-through.
+//
+// Single linear pass: marshal each entry once, accumulate, stop the
+// moment the running size would exceed max. Cheaper and simpler than
+// the prior binary-search version which re-marshaled growing prefixes.
+// Overhead per entry is bounded by the entry's own JSON size, which is
+// already capped by the recorder's count cap and the upstream payload
+// byte cap.
 func fitNotifications(in []audit.Notification, max int) ([]audit.Notification, bool) {
 	if len(in) == 0 || max <= 0 {
 		return in, false
 	}
-	if _, ok := jsonSizeWithin(in, max); ok {
-		return in, false
-	}
-	// Binary search for the longest prefix that fits, then return it.
-	lo, hi := 0, len(in)
-	for lo < hi {
-		mid := (lo + hi + 1) / 2
-		if _, ok := jsonSizeWithin(in[:mid], max); ok {
-			lo = mid
-		} else {
-			hi = mid - 1
+	const brackets = 2 // "[" + "]"
+	running := brackets
+	for i, n := range in {
+		b, err := json.Marshal(n)
+		if err != nil {
+			// A single bad entry shouldn't poison the whole slice; drop
+			// it and any tail by reporting truncation at this index.
+			return in[:i], true
+		}
+		if i > 0 {
+			running++ // ","
+		}
+		running += len(b)
+		if running > max {
+			return in[:i], true
 		}
 	}
-	return in[:lo], true
+	return in, false
 }
 
 // callToolResultToMap renders a CallToolResult in the same shape the

--- a/pkg/mcpmw/audit_payload_test.go
+++ b/pkg/mcpmw/audit_payload_test.go
@@ -207,6 +207,57 @@ func TestAudit_PayloadCapture_PreservesNonTextContent(t *testing.T) {
 	}
 }
 
+func TestAudit_PayloadCapturesNotifications(t *testing.T) {
+	// End-to-end: Audit (receiving) seeds a recorder onto ctx; the
+	// fake handler simulates a tool firing notifications by calling
+	// the Notifications sending middleware against the same ctx.
+	// The captured slice must land in Payload.Notifications.
+	mem := audit.NewMemoryLogger()
+	chain := auth.NewChain(true, nil, nil)
+	mw := Audit(chain, mem, nil, nil, WithPayloadCapture(0), WithMaxNotifications(10))
+	sender := Notifications()
+
+	wrapped := mw(func(ctx context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		// Simulate the tool firing two progress notifications via the
+		// sending pipeline. In the real server the tool calls
+		// req.Session.NotifyProgress which dispatches through the
+		// sending middleware chain; here we invoke the sending
+		// middleware directly with the same ctx.
+		passthrough := sender(func(context.Context, string, mcp.Request) (mcp.Result, error) {
+			return nil, nil
+		})
+		_, _ = passthrough(ctx, "notifications/progress",
+			&mcp.ServerRequest[*mcp.ProgressNotificationParams]{
+				Params: &mcp.ProgressNotificationParams{Progress: 1, Total: 3, Message: "step 1"},
+			})
+		_, _ = passthrough(ctx, "notifications/progress",
+			&mcp.ServerRequest[*mcp.ProgressNotificationParams]{
+				Params: &mcp.ProgressNotificationParams{Progress: 2, Total: 3, Message: "step 2"},
+			})
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "done"}}}, nil
+	})
+
+	req := &mcp.ServerRequest[*mcp.CallToolParams]{
+		Params: &mcp.CallToolParams{Name: "progress"},
+		Extra:  &mcp.RequestExtra{Header: http.Header{}},
+	}
+	_, _ = wrapped(context.Background(), "tools/call", req)
+
+	p := mem.Snapshot()[0].Payload
+	if p == nil {
+		t.Fatal("expected payload")
+	}
+	if len(p.Notifications) != 2 {
+		t.Fatalf("captured %d notifications, want 2", len(p.Notifications))
+	}
+	if p.Notifications[0].Method != "notifications/progress" {
+		t.Errorf("Method = %q", p.Notifications[0].Method)
+	}
+	if p.Notifications[0].Params["message"] != "step 1" {
+		t.Errorf("Params[message] = %v", p.Notifications[0].Params["message"])
+	}
+}
+
 func TestAudit_AuthFailureCarriesCategory(t *testing.T) {
 	// M-3 in the review: response_error must carry a structured
 	// category in addition to the message.

--- a/pkg/mcpmw/audit_payload_test.go
+++ b/pkg/mcpmw/audit_payload_test.go
@@ -258,6 +258,127 @@ func TestAudit_PayloadCapturesNotifications(t *testing.T) {
 	}
 }
 
+func TestAudit_PayloadNotifications_ByteCapTrims(t *testing.T) {
+	// A LogMessage carries an arbitrary `data any` blob; a small count
+	// can still blow past max_payload_bytes. Verify the byte cap trims
+	// trailing notifications and sets NotificationsTruncated.
+	mem := audit.NewMemoryLogger()
+	chain := auth.NewChain(true, nil, nil)
+	// 600 byte cap forces a trim while leaving room for a couple of entries.
+	mw := Audit(chain, mem, nil, nil, WithPayloadCapture(600), WithMaxNotifications(20))
+	sender := Notifications()
+
+	bigData := strings.Repeat("X", 80) // each notification ~ >100 bytes JSON
+
+	wrapped := mw(func(ctx context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		passthrough := sender(func(context.Context, string, mcp.Request) (mcp.Result, error) {
+			return nil, nil
+		})
+		for i := 0; i < 10; i++ {
+			_, _ = passthrough(ctx, "notifications/message",
+				&mcp.ServerRequest[*mcp.LoggingMessageParams]{
+					Params: &mcp.LoggingMessageParams{
+						Level: "info",
+						Data:  map[string]any{"i": i, "blob": bigData},
+					},
+				})
+		}
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "ok"}}}, nil
+	})
+
+	req := &mcp.ServerRequest[*mcp.CallToolParams]{
+		Params: &mcp.CallToolParams{Name: "noisy"},
+		Extra:  &mcp.RequestExtra{Header: http.Header{}},
+	}
+	_, _ = wrapped(context.Background(), "tools/call", req)
+
+	p := mem.Snapshot()[0].Payload
+	if p == nil {
+		t.Fatal("expected payload")
+	}
+	if !p.NotificationsTruncated {
+		t.Errorf("NotificationsTruncated = false, want true (cap 200 with 10 ~80b entries)")
+	}
+	if len(p.Notifications) >= 10 {
+		t.Errorf("notifications len = %d, want < 10 (some trimmed)", len(p.Notifications))
+	}
+	// First entry must always survive (binary-search keeps the longest fitting prefix).
+	if len(p.Notifications) == 0 {
+		t.Error("no notifications survived the trim; expected at least one")
+	}
+}
+
+func TestAudit_NotificationsRespectRedactKeys(t *testing.T) {
+	// Pipe-through: redactKeys passed to Audit must reach the recorder
+	// so notification params get the same sanitization as tool params.
+	mem := audit.NewMemoryLogger()
+	chain := auth.NewChain(true, nil, nil)
+	mw := Audit(chain, mem, []string{"token"}, nil, WithPayloadCapture(0))
+	sender := Notifications()
+
+	wrapped := mw(func(ctx context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		passthrough := sender(func(context.Context, string, mcp.Request) (mcp.Result, error) {
+			return nil, nil
+		})
+		_, _ = passthrough(ctx, "notifications/message",
+			&mcp.ServerRequest[*mcp.LoggingMessageParams]{
+				Params: &mcp.LoggingMessageParams{
+					Level: "info",
+					Data:  map[string]any{"step": 1, "token": "leaked-secret"},
+				},
+			})
+		return &mcp.CallToolResult{}, nil
+	})
+
+	req := &mcp.ServerRequest[*mcp.CallToolParams]{
+		Params: &mcp.CallToolParams{Name: "noisy"},
+		Extra:  &mcp.RequestExtra{Header: http.Header{}},
+	}
+	_, _ = wrapped(context.Background(), "tools/call", req)
+
+	p := mem.Snapshot()[0].Payload
+	if p == nil || len(p.Notifications) != 1 {
+		t.Fatalf("expected 1 notification, got payload=%+v", p)
+	}
+	data, _ := p.Notifications[0].Params["data"].(map[string]any)
+	if data == nil {
+		t.Fatalf("data field missing/wrong type: %+v", p.Notifications[0].Params)
+	}
+	if data["token"] != "[redacted]" {
+		t.Errorf("token = %v, want [redacted]", data["token"])
+	}
+}
+
+func TestAudit_HandlerErrorCategoryMatchesPayload(t *testing.T) {
+	// The post-call categorization must set ev.ErrorCategory and the
+	// payload's response_error.category to the same value. Previously
+	// "handler" went into the payload but ev.ErrorCategory was left
+	// empty, so the indexed field disagreed with the detail row.
+	mem := audit.NewMemoryLogger()
+	chain := auth.NewChain(true, nil, nil)
+	mw := Audit(chain, mem, nil, nil, WithPayloadCapture(0))
+
+	wrapped := mw(func(context.Context, string, mcp.Request) (mcp.Result, error) {
+		return nil, errors.New("handler exploded")
+	})
+	req := &mcp.ServerRequest[*mcp.CallToolParams]{
+		Params: &mcp.CallToolParams{Name: "broken"},
+		Extra:  &mcp.RequestExtra{Header: http.Header{}},
+	}
+	_, _ = wrapped(context.Background(), "tools/call", req)
+
+	ev := mem.Snapshot()[0]
+	if ev.ErrorCategory != "handler" {
+		t.Errorf("ev.ErrorCategory = %q, want handler", ev.ErrorCategory)
+	}
+	if ev.Payload == nil || ev.Payload.ResponseError == nil {
+		t.Fatalf("expected payload with response_error, got %+v", ev.Payload)
+	}
+	if ev.Payload.ResponseError["category"] != "handler" {
+		t.Errorf("payload category = %v, want handler", ev.Payload.ResponseError["category"])
+	}
+}
+
 func TestAudit_AuthFailureCarriesCategory(t *testing.T) {
 	// M-3 in the review: response_error must carry a structured
 	// category in addition to the message.

--- a/pkg/mcpmw/audit_payload_test.go
+++ b/pkg/mcpmw/audit_payload_test.go
@@ -158,6 +158,98 @@ func TestAudit_PayloadCapture_HeadersOptIn(t *testing.T) {
 	}
 }
 
+func TestAudit_PayloadCapture_PreservesNonTextContent(t *testing.T) {
+	// An EmbeddedResource block (i.e. not text/image/audio) must fall
+	// through callToolResultToMap's JSON-marshal path so the actual
+	// resource data lands in the payload row, not a "non-textual block"
+	// placeholder. Regression coverage for M-2 in the PR review.
+	mem := audit.NewMemoryLogger()
+	chain := auth.NewChain(true, nil, nil)
+	mw := Audit(chain, mem, nil, nil, WithPayloadCapture(0))
+
+	wrapped := mw((&fakeMethodHandler{
+		res: &mcp.CallToolResult{Content: []mcp.Content{
+			&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+				URI:      "file:///tmp/example.txt",
+				MIMEType: "text/plain",
+				Text:     "hello from the resource",
+			}},
+		}},
+	}).handle)
+
+	req := &mcp.ServerRequest[*mcp.CallToolParams]{
+		Params: &mcp.CallToolParams{Name: "echo"},
+		Extra:  &mcp.RequestExtra{Header: http.Header{}},
+	}
+	_, _ = wrapped(context.Background(), "tools/call", req)
+
+	p := mem.Snapshot()[0].Payload
+	if p == nil {
+		t.Fatal("expected payload")
+	}
+	blocks, _ := p.ResponseResult["content"].([]any)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	first, _ := blocks[0].(map[string]any)
+	if first["type"] != "resource" {
+		t.Errorf("type = %v, want \"resource\" (from MarshalJSON)", first["type"])
+	}
+	res, _ := first["resource"].(map[string]any)
+	if res == nil {
+		t.Fatalf("expected resource sub-object, got: %v", first)
+	}
+	if res["uri"] != "file:///tmp/example.txt" {
+		t.Errorf("resource.uri = %v", res["uri"])
+	}
+	if res["text"] != "hello from the resource" {
+		t.Errorf("resource.text = %v", res["text"])
+	}
+}
+
+func TestAudit_AuthFailureCarriesCategory(t *testing.T) {
+	// M-3 in the review: response_error must carry a structured
+	// category in addition to the message.
+	mem := audit.NewMemoryLogger()
+	chain := auth.NewChain(false, nil, nil) // anonymous off + no stores → fails
+	mw := Audit(chain, mem, nil, nil, WithPayloadCapture(0))
+	wrapped := mw((&fakeMethodHandler{}).handle)
+
+	req := &mcp.ServerRequest[*mcp.CallToolParams]{
+		Params: &mcp.CallToolParams{Name: "echo"},
+		Extra:  &mcp.RequestExtra{Header: http.Header{"User-Agent": []string{"x"}}},
+	}
+	_, _ = wrapped(context.Background(), "tools/call", req)
+	p := mem.Snapshot()[0].Payload
+	if p == nil {
+		t.Fatal("expected payload")
+	}
+	if p.ResponseError == nil {
+		t.Fatal("expected response_error")
+	}
+	if cat, _ := p.ResponseError["category"].(string); cat != "auth" {
+		t.Errorf("response_error.category = %q, want auth", cat)
+	}
+}
+
+func TestAudit_PayloadCaptures_DispatchedMethod(t *testing.T) {
+	// M-1 in the review: jsonrpc_method must reflect what the receiving
+	// middleware actually saw, not a hard-coded "tools/call" string.
+	mem := audit.NewMemoryLogger()
+	chain := auth.NewChain(true, nil, nil)
+	mw := Audit(chain, mem, nil, nil, WithPayloadCapture(0))
+	wrapped := mw((&fakeMethodHandler{}).handle)
+	req := &mcp.ServerRequest[*mcp.CallToolParams]{
+		Params: &mcp.CallToolParams{Name: "echo"},
+		Extra:  &mcp.RequestExtra{Header: http.Header{}},
+	}
+	_, _ = wrapped(context.Background(), "tools/call", req)
+	p := mem.Snapshot()[0].Payload
+	if p.JSONRPCMethod != "tools/call" {
+		t.Errorf("JSONRPCMethod = %q, want tools/call", p.JSONRPCMethod)
+	}
+}
+
 func TestAudit_AuthFailure_StillCapturesPayload(t *testing.T) {
 	mem := audit.NewMemoryLogger()
 	chain := auth.NewChain(false, nil, nil) // no anonymous, no stores → auth fails

--- a/pkg/mcpmw/notifications.go
+++ b/pkg/mcpmw/notifications.go
@@ -51,20 +51,37 @@ func newNotificationRecorder(max int, redactKeys []string) *notificationRecorder
 // same redactKeys configured on the Audit middleware, so a tool that
 // emits a sensitive value in a NotifyProgress message or LogMessage
 // data blob does not bypass the operator's redact list.
+//
+// Concurrency: the JSON round-trip and sanitize pass run BEFORE the
+// mutex is taken so concurrent NotifyProgress calls don't serialize
+// behind one another's marshal cost. We do a quick locked cap check
+// first to skip the work entirely when the recorder is already full;
+// the second check after re-acquiring the lock guards against the race
+// between the two locks.
 func (r *notificationRecorder) Append(method string, params any) {
 	if r == nil {
 		return
 	}
+	// Fast path: bail without allocating if we're already at cap.
+	r.mu.Lock()
+	full := r.max > 0 && len(r.items) >= r.max
+	r.mu.Unlock()
+	if full {
+		return
+	}
+
+	note := audit.Notification{
+		Timestamp: time.Now().UTC(),
+		Method:    method,
+		Params:    audit.SanitizeParameters(paramsToMap(params), r.redactKeys),
+	}
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.max > 0 && len(r.items) >= r.max {
 		return
 	}
-	r.items = append(r.items, audit.Notification{
-		Timestamp: time.Now().UTC(),
-		Method:    method,
-		Params:    audit.SanitizeParameters(paramsToMap(params), r.redactKeys),
-	})
+	r.items = append(r.items, note)
 }
 
 // Snapshot returns a copy of the recorded notifications. Caller must not

--- a/pkg/mcpmw/notifications.go
+++ b/pkg/mcpmw/notifications.go
@@ -1,0 +1,128 @@
+package mcpmw
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/plexara/mcp-test/pkg/audit"
+)
+
+// notificationRecorder collects server-initiated notifications (progress
+// updates, log messages, anything else the SDK sends with a method
+// prefixed "notifications/") fired during one tool-call window.
+//
+// The receiving Audit middleware creates a recorder per call, stashes
+// it on ctx, and reads the captured slice back after the call returns.
+// The sending middleware (Notifications) reads the recorder off the
+// same ctx and appends as notifications fire.
+//
+// Append is safe for concurrent use; tools that fan out goroutines can
+// each call NotifyProgress without external synchronization.
+type notificationRecorder struct {
+	mu    sync.Mutex
+	items []audit.Notification
+	max   int
+}
+
+func newNotificationRecorder(max int) *notificationRecorder {
+	return &notificationRecorder{max: max}
+}
+
+// Append records one notification. Drops past the cap so a tool that
+// emits in a tight loop can't grow the recorder unboundedly. The
+// dropped count isn't surfaced today; if it matters later the type can
+// expose it.
+func (r *notificationRecorder) Append(method string, params any) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.max > 0 && len(r.items) >= r.max {
+		return
+	}
+	r.items = append(r.items, audit.Notification{
+		Timestamp: time.Now().UTC(),
+		Method:    method,
+		Params:    paramsToMap(params),
+	})
+}
+
+// Snapshot returns a copy of the recorded notifications. Caller must not
+// mutate the returned slice; further Appends won't be reflected.
+func (r *notificationRecorder) Snapshot() []audit.Notification {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.items) == 0 {
+		return nil
+	}
+	out := make([]audit.Notification, len(r.items))
+	copy(out, r.items)
+	return out
+}
+
+// paramsToMap renders any SDK-typed Params into a generic map so the
+// recorder doesn't have to know about every notification shape. The
+// SDK's notification params implement json.Marshaler with the wire
+// shape; round-trip through JSON.
+func paramsToMap(params any) map[string]any {
+	if params == nil {
+		return nil
+	}
+	b, err := json.Marshal(params)
+	if err != nil {
+		return map[string]any{"_marshal_error": err.Error()}
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		return map[string]any{"_unmarshal_error": err.Error(), "_raw": string(b)}
+	}
+	return m
+}
+
+// recorderKey is the ctx key for the per-call notification recorder.
+type recorderKey struct{}
+
+func withRecorder(ctx context.Context, r *notificationRecorder) context.Context {
+	return context.WithValue(ctx, recorderKey{}, r)
+}
+
+func getRecorder(ctx context.Context) *notificationRecorder {
+	r, _ := ctx.Value(recorderKey{}).(*notificationRecorder)
+	return r
+}
+
+// Notifications returns a sending-side middleware that records every
+// notifications/* method dispatched during the call window of a
+// tool/call request. The receiving Audit middleware seeds the
+// recorder onto ctx; without it (e.g. a notifications dispatch outside
+// any tool call) this middleware is a no-op.
+//
+// Wire alongside Audit at server boot:
+//
+//	mcpServer.AddReceivingMiddleware(mcpmw.Audit(...))
+//	mcpServer.AddSendingMiddleware(mcpmw.Notifications())
+func Notifications() mcp.Middleware {
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			if isNotification(method) {
+				if r := getRecorder(ctx); r != nil {
+					r.Append(method, req.GetParams())
+				}
+			}
+			return next(ctx, method, req)
+		}
+	}
+}
+
+func isNotification(method string) bool {
+	const prefix = "notifications/"
+	return len(method) >= len(prefix) && method[:len(prefix)] == prefix
+}

--- a/pkg/mcpmw/notifications.go
+++ b/pkg/mcpmw/notifications.go
@@ -3,6 +3,7 @@ package mcpmw
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"sync"
 	"time"
 
@@ -22,20 +23,34 @@ import (
 //
 // Append is safe for concurrent use; tools that fan out goroutines can
 // each call NotifyProgress without external synchronization.
+//
+// The recorder is read once via Snapshot() right after the receiving
+// handler returns. Goroutines that fire notifications AFTER the handler
+// returns can still Append safely (the mutex makes that race-free) but
+// their entries will not be in the snapshot and are dropped silently.
+// This is a deliberate trade-off: post-return notifications are an MCP
+// anti-pattern, and the alternative (waiting for stragglers) would
+// stall the audit pipeline behind a buggy tool.
 type notificationRecorder struct {
-	mu    sync.Mutex
-	items []audit.Notification
-	max   int
+	mu         sync.Mutex
+	items      []audit.Notification
+	max        int
+	redactKeys []string
 }
 
-func newNotificationRecorder(max int) *notificationRecorder {
-	return &notificationRecorder{max: max}
+func newNotificationRecorder(max int, redactKeys []string) *notificationRecorder {
+	return &notificationRecorder{max: max, redactKeys: redactKeys}
 }
 
 // Append records one notification. Drops past the cap so a tool that
 // emits in a tight loop can't grow the recorder unboundedly. The
 // dropped count isn't surfaced today; if it matters later the type can
 // expose it.
+//
+// Notification params are run through audit.SanitizeParameters with the
+// same redactKeys configured on the Audit middleware, so a tool that
+// emits a sensitive value in a NotifyProgress message or LogMessage
+// data blob does not bypass the operator's redact list.
 func (r *notificationRecorder) Append(method string, params any) {
 	if r == nil {
 		return
@@ -48,7 +63,7 @@ func (r *notificationRecorder) Append(method string, params any) {
 	r.items = append(r.items, audit.Notification{
 		Timestamp: time.Now().UTC(),
 		Method:    method,
-		Params:    paramsToMap(params),
+		Params:    audit.SanitizeParameters(paramsToMap(params), r.redactKeys),
 	})
 }
 
@@ -123,6 +138,5 @@ func Notifications() mcp.Middleware {
 }
 
 func isNotification(method string) bool {
-	const prefix = "notifications/"
-	return len(method) >= len(prefix) && method[:len(prefix)] == prefix
+	return strings.HasPrefix(method, "notifications/")
 }

--- a/pkg/mcpmw/notifications_test.go
+++ b/pkg/mcpmw/notifications_test.go
@@ -1,0 +1,158 @@
+package mcpmw
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestNotificationRecorder_AppendAndSnapshot(t *testing.T) {
+	r := newNotificationRecorder(0) // 0 = no cap
+	r.Append("notifications/progress", &mcp.ProgressNotificationParams{
+		Progress: 1, Total: 3, Message: "step 1/3",
+	})
+	r.Append("notifications/progress", &mcp.ProgressNotificationParams{
+		Progress: 2, Total: 3, Message: "step 2/3",
+	})
+
+	snap := r.Snapshot()
+	if len(snap) != 2 {
+		t.Fatalf("snapshot len = %d, want 2", len(snap))
+	}
+	if snap[0].Method != "notifications/progress" {
+		t.Errorf("Method = %q", snap[0].Method)
+	}
+	if snap[0].Params["message"] != "step 1/3" {
+		t.Errorf("Params[message] = %v", snap[0].Params["message"])
+	}
+	if snap[0].Timestamp.IsZero() {
+		t.Error("Timestamp should be populated")
+	}
+}
+
+func TestNotificationRecorder_CapDropsExcess(t *testing.T) {
+	r := newNotificationRecorder(2)
+	r.Append("notifications/progress", nil)
+	r.Append("notifications/progress", nil)
+	r.Append("notifications/progress", nil) // dropped
+	r.Append("notifications/progress", nil) // dropped
+	if got := len(r.Snapshot()); got != 2 {
+		t.Errorf("snapshot len = %d, want 2 (cap)", got)
+	}
+}
+
+func TestNotificationRecorder_NilSafe(t *testing.T) {
+	var r *notificationRecorder
+	r.Append("anything", nil) // must not panic
+	if got := r.Snapshot(); got != nil {
+		t.Errorf("nil receiver Snapshot = %v, want nil", got)
+	}
+}
+
+func TestNotificationRecorder_ConcurrentAppend(t *testing.T) {
+	r := newNotificationRecorder(0)
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r.Append("notifications/progress", nil)
+		}()
+	}
+	wg.Wait()
+	if got := len(r.Snapshot()); got != 100 {
+		t.Errorf("after 100 concurrent appends, len = %d, want 100", got)
+	}
+}
+
+func TestNotifications_NoRecorderOnCtx_NoOp(t *testing.T) {
+	// Without a recorder seeded on ctx, the sending middleware just
+	// passes through without panicking.
+	called := false
+	mw := Notifications()
+	wrapped := mw(func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		called = true
+		return nil, nil
+	})
+	_, _ = wrapped(context.Background(), "notifications/progress",
+		&mcp.ServerRequest[*mcp.ProgressNotificationParams]{
+			Params: &mcp.ProgressNotificationParams{Progress: 1},
+		})
+	if !called {
+		t.Error("next should be called even without recorder")
+	}
+}
+
+func TestNotifications_RecordsWhenRecorderPresent(t *testing.T) {
+	r := newNotificationRecorder(0)
+	ctx := withRecorder(context.Background(), r)
+
+	mw := Notifications()
+	wrapped := mw(func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		return nil, nil
+	})
+	_, _ = wrapped(ctx, "notifications/progress",
+		&mcp.ServerRequest[*mcp.ProgressNotificationParams]{
+			Params: &mcp.ProgressNotificationParams{Progress: 1, Total: 5, Message: "halfway"},
+		})
+
+	snap := r.Snapshot()
+	if len(snap) != 1 {
+		t.Fatalf("recorded %d, want 1", len(snap))
+	}
+	if snap[0].Method != "notifications/progress" {
+		t.Errorf("Method = %q", snap[0].Method)
+	}
+}
+
+func TestNotifications_IgnoresNonNotificationMethods(t *testing.T) {
+	// The middleware sees every outbound method; only "notifications/*"
+	// should land in the recorder. A "ping" or "logging/*" method
+	// shouldn't.
+	r := newNotificationRecorder(0)
+	ctx := withRecorder(context.Background(), r)
+
+	mw := Notifications()
+	wrapped := mw(func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		return nil, nil
+	})
+	_, _ = wrapped(ctx, "ping",
+		&mcp.ServerRequest[*mcp.PingParams]{Params: &mcp.PingParams{}})
+
+	if got := r.Snapshot(); got != nil {
+		t.Errorf("non-notification method recorded: %+v", got)
+	}
+}
+
+func TestIsNotification(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"notifications/progress", true},
+		{"notifications/initialized", true},
+		{"notifications/logging/message", true},
+		{"ping", false},
+		{"tools/call", false},
+		{"", false},
+		{"notifications", false}, // missing trailing /
+	}
+	for _, c := range cases {
+		if got := isNotification(c.in); got != c.want {
+			t.Errorf("isNotification(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParamsToMap_NilAndError(t *testing.T) {
+	if got := paramsToMap(nil); got != nil {
+		t.Errorf("nil params -> %v, want nil", got)
+	}
+	// SDK params marshal cleanly; non-marshalable inputs (e.g. a chan)
+	// should hit the error path without panicking.
+	if got := paramsToMap(make(chan int)); got["_marshal_error"] == nil {
+		t.Errorf("expected _marshal_error key for unmarshalable input, got %+v", got)
+	}
+}

--- a/pkg/mcpmw/notifications_test.go
+++ b/pkg/mcpmw/notifications_test.go
@@ -157,6 +157,26 @@ func TestParamsToMap_NilAndError(t *testing.T) {
 	}
 }
 
+func TestNotificationRecorder_PostSnapshotAppendsAreDropped(t *testing.T) {
+	// The doc comment promises that goroutines firing notifications
+	// after the receiving handler returns Snapshot()-ed are silently
+	// dropped from THAT snapshot. Lock that contract.
+	r := newNotificationRecorder(0, nil)
+	r.Append("notifications/progress", map[string]any{"step": 1})
+	first := r.Snapshot()
+	if len(first) != 1 {
+		t.Fatalf("first snapshot len = %d, want 1", len(first))
+	}
+	r.Append("notifications/progress", map[string]any{"step": 2})
+	if len(first) != 1 {
+		t.Errorf("snapshot copy was mutated retroactively: len = %d", len(first))
+	}
+	second := r.Snapshot()
+	if len(second) != 2 {
+		t.Errorf("second snapshot len = %d, want 2 (post-snapshot Append must persist on the recorder)", len(second))
+	}
+}
+
 func TestNotificationRecorder_AppliesRedactKeys(t *testing.T) {
 	// Notification params must be sanitized with the same redactKeys as
 	// tool params; otherwise a tool can leak a secret via NotifyProgress

--- a/pkg/mcpmw/notifications_test.go
+++ b/pkg/mcpmw/notifications_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestNotificationRecorder_AppendAndSnapshot(t *testing.T) {
-	r := newNotificationRecorder(0) // 0 = no cap
+	r := newNotificationRecorder(0, nil) // 0 = no cap
 	r.Append("notifications/progress", &mcp.ProgressNotificationParams{
 		Progress: 1, Total: 3, Message: "step 1/3",
 	})
@@ -33,7 +33,7 @@ func TestNotificationRecorder_AppendAndSnapshot(t *testing.T) {
 }
 
 func TestNotificationRecorder_CapDropsExcess(t *testing.T) {
-	r := newNotificationRecorder(2)
+	r := newNotificationRecorder(2, nil)
 	r.Append("notifications/progress", nil)
 	r.Append("notifications/progress", nil)
 	r.Append("notifications/progress", nil) // dropped
@@ -52,7 +52,7 @@ func TestNotificationRecorder_NilSafe(t *testing.T) {
 }
 
 func TestNotificationRecorder_ConcurrentAppend(t *testing.T) {
-	r := newNotificationRecorder(0)
+	r := newNotificationRecorder(0, nil)
 	var wg sync.WaitGroup
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
@@ -86,7 +86,7 @@ func TestNotifications_NoRecorderOnCtx_NoOp(t *testing.T) {
 }
 
 func TestNotifications_RecordsWhenRecorderPresent(t *testing.T) {
-	r := newNotificationRecorder(0)
+	r := newNotificationRecorder(0, nil)
 	ctx := withRecorder(context.Background(), r)
 
 	mw := Notifications()
@@ -111,7 +111,7 @@ func TestNotifications_IgnoresNonNotificationMethods(t *testing.T) {
 	// The middleware sees every outbound method; only "notifications/*"
 	// should land in the recorder. A "ping" or "logging/*" method
 	// shouldn't.
-	r := newNotificationRecorder(0)
+	r := newNotificationRecorder(0, nil)
 	ctx := withRecorder(context.Background(), r)
 
 	mw := Notifications()
@@ -154,5 +154,45 @@ func TestParamsToMap_NilAndError(t *testing.T) {
 	// should hit the error path without panicking.
 	if got := paramsToMap(make(chan int)); got["_marshal_error"] == nil {
 		t.Errorf("expected _marshal_error key for unmarshalable input, got %+v", got)
+	}
+}
+
+func TestNotificationRecorder_AppliesRedactKeys(t *testing.T) {
+	// Notification params must be sanitized with the same redactKeys as
+	// tool params; otherwise a tool can leak a secret via NotifyProgress
+	// or LogMessage and bypass the operator's redact list.
+	r := newNotificationRecorder(0, []string{"token", "password"})
+	r.Append("notifications/progress", map[string]any{
+		"step":     1,
+		"token":    "should-be-redacted",
+		"password": "also-redacted",
+		"nested": map[string]any{
+			"safe":     "ok",
+			"apiToken": "redacted-by-substring",
+		},
+	})
+	snap := r.Snapshot()
+	if len(snap) != 1 {
+		t.Fatalf("snap len = %d", len(snap))
+	}
+	p := snap[0].Params
+	if p["token"] != "[redacted]" {
+		t.Errorf("token = %v, want [redacted]", p["token"])
+	}
+	if p["password"] != "[redacted]" {
+		t.Errorf("password = %v, want [redacted]", p["password"])
+	}
+	if p["step"] != float64(1) { // JSON round-trip: int becomes float64
+		t.Errorf("step = %v (%T), want 1", p["step"], p["step"])
+	}
+	nested, _ := p["nested"].(map[string]any)
+	if nested == nil {
+		t.Fatalf("nested missing: %+v", p)
+	}
+	if nested["safe"] != "ok" {
+		t.Errorf("nested.safe = %v, want ok", nested["safe"])
+	}
+	if nested["apiToken"] != "[redacted]" {
+		t.Errorf("nested.apiToken = %v, want [redacted] (substring match)", nested["apiToken"])
 	}
 }

--- a/tests/audit_notifications_test.go
+++ b/tests/audit_notifications_test.go
@@ -1,0 +1,80 @@
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/plexara/mcp-test/pkg/audit"
+)
+
+// TestHTTP_NotificationsCapturedInAuditPayload locks the SDK contract this
+// PR depends on: that mcp.Server.AddSendingMiddleware is invoked when a
+// tool calls req.Session.NotifyProgress, and that the recorder seeded by
+// the receiving Audit middleware ends up populated by the time the
+// audit row is written.
+//
+// The unit tests in pkg/mcpmw cover the middleware in isolation; this
+// test boots the full HTTP stack so a future SDK refactor that decouples
+// NotifyProgress from the sending pipeline (or changes the ctx flow)
+// surfaces here instead of silently zeroing out audit_payloads.notifications.
+func TestHTTP_NotificationsCapturedInAuditPayload(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	ts, mem := httpTestApp(t)
+
+	session := connectClient(t, ctx, ts, nil, nil)
+
+	steps := 3
+	params := &mcp.CallToolParams{
+		Name:      "progress",
+		Arguments: map[string]any{"steps": steps, "step_ms": 5},
+	}
+	params.SetProgressToken("audit-cap-1")
+	res, err := session.CallTool(ctx, params)
+	if err != nil {
+		t.Fatalf("call progress: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("progress returned IsError")
+	}
+
+	ev := waitForEvent(t, mem, "progress", 2*time.Second)
+
+	if ev.Payload == nil {
+		t.Fatalf("event has no payload row; capture_payloads should default on")
+	}
+	if len(ev.Payload.Notifications) < steps {
+		t.Fatalf("notifications captured = %d, want >= %d (payload: %+v)",
+			len(ev.Payload.Notifications), steps, ev.Payload.Notifications)
+	}
+	for i, n := range ev.Payload.Notifications {
+		if n.Method != "notifications/progress" {
+			t.Errorf("n[%d].Method = %q, want notifications/progress", i, n.Method)
+		}
+		if n.Params == nil {
+			t.Errorf("n[%d].Params nil", i)
+			continue
+		}
+		if _, ok := n.Params["progress"]; !ok {
+			t.Errorf("n[%d].Params missing progress key: %+v", i, n.Params)
+		}
+	}
+}
+
+func waitForEvent(t *testing.T, mem *audit.MemoryLogger, toolName string, timeout time.Duration) audit.Event {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		for _, e := range mem.Snapshot() {
+			if e.ToolName == toolName {
+				return e
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("audit event for tool %q never landed within %v", toolName, timeout)
+	return audit.Event{}
+}


### PR DESCRIPTION
Second slice of [#8](https://github.com/plexara/mcp-test/issues/8). Closes off two of the nine subtasks: the **review-fix cleanup** that was unmerged on PR #5, and the **notification recorder** that PR #5 stubbed in the schema but did not implement. Replay endpoint, SSE tail, JSONB filter compiler, NDJSON export, UI drawer, comparison page, and docs remain as separate follow-ups on top of this.

## What's in this PR

### Notification recorder (`pkg/mcpmw/notifications.go`)

- New `notificationRecorder`: per-request, ctx-keyed, mutex-guarded, capped via `WithMaxNotifications(n)`. Concurrent-safe so tools that fan out goroutines can each call `NotifyProgress` without external synchronization. Drops past the cap rather than growing unboundedly.
- New `mcpmw.Notifications()` sending-side middleware. On every dispatched method it checks `isNotification(method)` and, if a recorder is on ctx, appends `{timestamp, method, params}`. No-op when no recorder is seeded (e.g. notifications dispatched outside a tool-call window).
- `paramsToMap` renders SDK-typed `Params` via JSON round-trip so the recorder does not have to know each notification shape; `notifications/progress`, `notifications/logging/message`, and anything else flow through unchanged.

### Wiring (`pkg/mcpmw/audit.go`, `internal/server/server.go`)

- The receiving `Audit` middleware now seeds a `notificationRecorder` onto ctx whenever `capture_payloads` is on, then passes its `Snapshot()` into `buildPayload`. The captured slice lands in `audit_payloads.notifications`.
- `internal/server/server.go` wires `mcpServer.AddSendingMiddleware(mcpmw.Notifications())` next to the existing `AddReceivingMiddleware(mcpmw.Audit(...))`.
- Drive-by fix in the same file: `errCategory = "handler"` no longer overwrites a category (`tool`, `auth_failed`) set upstream. Was a regression noted in the PR #5 review; covered by `TestAudit_AuthFailureCarriesCategory`.

### PR #5 review-fix cleanup

Re-applies the fixes that lived on the local-only `feat/audit-inspection-issue-4 @ b192c8e` and never made `main`. Tracked as the first checkbox in #8.

- `pkg/mcpmw/audit.go` / `audit_payload_test.go`: `errCategory` precedence (`auth_failed` > `tool` > `handler`); `callToolResultToMap` uniform JSON round-trip so annotations on text/image/audio content blocks survive instead of being silently dropped.
- `pkg/audit/event.go`, `pkg/httpsrv/portal_api.go`: `response_error.category` populated alongside `message` so the portal can show "auth rejected" vs "tool errored" without parsing strings.
- `pkg/audit/postgres/store.go`: reflection-based `isEmptyValue` for `marshalJSONB` (was previously hand-rolled per type and missed slices); `unmarshalCol` with WARN logging on corrupt JSONB so a single bad row does not 500 the detail endpoint.
- `pkg/audit/postgres/store_test.go`: new testcontainers-backed Postgres store tests covering the JSONB round-trip, transactional `Log`, payload retrieval, and corrupt-row handling.
- `pkg/audit/postgres/migrate/migrations/0002_audit_payloads.up.sql`: schema follow-ups from the same review.
- `internal/server/audit_options_test.go`: config-side coverage for `auditOptions(cfg.Audit)` translation.
- `configs/mcp-test.{example,dev,live}.yaml`: documents `max_notifications` alongside the existing capture knobs.

## Tests

| File | Coverage |
|---|---|
| `pkg/mcpmw/notifications_test.go` | recorder append/snapshot/cap, nil-receiver safety, 100-goroutine concurrent append; middleware no-op without ctx, records when present, ignores non-`notifications/*` methods; `isNotification` table tests; `paramsToMap` nil and unmarshalable-input paths |
| `pkg/mcpmw/audit_payload_test.go` | new `TestAudit_PayloadCapturesNotifications` end-to-end: receiving Audit seeds the recorder, the fake handler fires two progress notifications via the sending middleware against the same ctx, both land in `Payload.Notifications` with the right method and params |
| `pkg/audit/postgres/store_test.go` | testcontainers Postgres: `Log` round-trip, payload join, JSONB empties, `unmarshalCol` warn path |
| `internal/server/audit_options_test.go` | `auditOptions` produces the expected `[]mcpmw.AuditOption` slice for each config shape |

## Closes (subtasks of #8)

- [x] Review-fix cleanup (was unmerged on PR #5)
- [x] Notification recorder

Does not close the umbrella issue. Remaining: replay endpoint, SSE live tail, JSONB path filter compiler, NDJSON export, portal UI drawer, comparison page, and `docs/operations/inspection.md`.

## Test plan

- [x] `go test ./...` green locally
- [ ] `make verify` green at >=80% filtered coverage
- [ ] Bring up `make dev`, call a tool that fires `NotifyProgress` (e.g. `mcptest__progress`), `SELECT notifications FROM audit_payloads WHERE event_id = '<id>'` returns a JSONB array with two elements, each `{ts, method: "notifications/progress", params: {progress, total, message}}`
- [ ] Override `audit.max_notifications: 3` in config, fire a tool that emits 10 notifications, confirm the stored array has exactly 3 entries
- [ ] Set `audit.capture_payloads: false`, fire the same tool, confirm no `audit_payloads` row is written and the receiver does not seed a recorder (no extra ctx allocation per call)
- [ ] Trigger an auth-rejected call, confirm `response_error.category = "auth_failed"` (not `"handler"`) in the resulting event