### PR TITLE
feat(audit): JSONB path filters and NDJSON export (#8)

### DIFF
--- a/docs/operations/audit.md
+++ b/docs/operations/audit.md
@@ -119,6 +119,12 @@ you need the full envelope, follow up with
 `/audit/events/{id}` per event. The endpoint caps at 100,000 rows
 per request; tighten the filter window for larger sets.
 
+`limit` and `offset` behave differently from `/events`:
+`limit` clamps the total exported row count (still bounded by
+the 100,000 hard cap), and `offset` is ignored — exports always
+start from the head of the matching set. Use `from` / `to` to
+window in time instead.
+
 All of these accept either the session cookie (browser) or
 `X-API-Key` / `Authorization: Bearer`.
 

--- a/docs/operations/audit.md
+++ b/docs/operations/audit.md
@@ -121,8 +121,8 @@ per request; tighten the filter window for larger sets.
 
 `limit` and `offset` behave differently from `/events`:
 `limit` clamps the total exported row count (still bounded by
-the 100,000 hard cap), and `offset` is ignored — exports always
-start from the head of the matching set. Use `from` / `to` to
+the 100,000 hard cap), and `offset` is ignored. Exports always
+start from the head of the matching set; use `from` / `to` to
 window in time instead.
 
 All of these accept either the session cookie (browser) or

--- a/docs/operations/audit.md
+++ b/docs/operations/audit.md
@@ -10,6 +10,15 @@ table. Auth failures, the portal's Try-It proxy, and direct admin-API
 invocations all show up there too, with different `source` tags so
 you can filter by origin.
 
+## Two-table layout
+
+As of v1.1.0 audit data lives in two tables joined 1:1 by event ID:
+
+- `audit_events`: indexed summary used for time-range, tool, user, success, and free-text queries. Small rows, hot path.
+- `audit_payloads`: full request and response envelope (parameters, headers, result content blocks, captured notifications, error categories). Optional, written in the same transaction as the summary; absent when `audit.capture_payloads: false` or when the deployment predates v1.1.0.
+
+Cascade delete on the foreign key keeps retention atomic: deleting an `audit_events` row drops its payload row in the same statement.
+
 ## What gets recorded
 
 | Column | Source |
@@ -49,10 +58,66 @@ p50 / p95 latency, unique users / tools, and a recent-activity table.
 
 | Endpoint | Returns |
 | --- | --- |
-| `GET /api/v1/portal/audit/events` | Paginated event list. Query params: `from`, `to` (RFC 3339), `tool`, `user`, `session`, `success` (`true`/`false`), `q` (free text), `limit`, `offset`. |
+| `GET /api/v1/portal/audit/events` | Paginated event list. Query params: `from`, `to` (RFC 3339), `tool`, `user`, `session`, `success` (`true`/`false`), `q` (free text), `limit`, `offset`. Plus the JSONB filters in the next section. |
+| `GET /api/v1/portal/audit/events/{id}` | Single event with captured payload (when present). |
+| `GET /api/v1/portal/audit/export` | NDJSON stream of summary rows. Same filter surface as `/events`. Capped at 100,000 rows per request. |
 | `GET /api/v1/portal/audit/timeseries` | Bucketed counts. Query params: `from`, `to`, `bucket` (Go duration like `1m`, `5m`). Returns `[{time, count, errors, avg_duration_ms}]`. |
 | `GET /api/v1/portal/audit/breakdown` | Group-by aggregations. Query param: `by` (one of `tool`, `user`, `success`, `auth_type`). Returns `[{key, count, errors}]`. |
 | `GET /api/v1/portal/dashboard` | The 1-hour summary. |
+
+### JSONB filters
+
+`/events` and `/export` accept JSONB-aware filters that hit the
+`audit_payloads` sibling row. Use them to narrow by parameter values,
+response shape, request headers, or presence of a payload column.
+
+```bash
+# Calls where the request param user.id equals "alice"
+curl -H "X-API-Key: $KEY" \
+  "$BASE/api/v1/portal/audit/events?param.user.id=alice"
+
+# Tool-error responses (response.isError matches JSON true)
+curl -H "X-API-Key: $KEY" \
+  "$BASE/api/v1/portal/audit/events?response.isError=true"
+
+# Match a User-Agent in request headers
+curl -H "X-API-Key: $KEY" \
+  "$BASE/api/v1/portal/audit/events?header.User-Agent=curl/8.0"
+
+# Only events that recorded notifications
+curl -H "X-API-Key: $KEY" \
+  "$BASE/api/v1/portal/audit/events?has=notifications"
+
+# Combine: tool-errors that emitted notifications, last hour
+curl -H "X-API-Key: $KEY" \
+  "$BASE/api/v1/portal/audit/events?response.isError=true&has=notifications&from=$(date -u -v-1H +%FT%TZ)"
+```
+
+Values are type-detected: `true` / `false` become JSON booleans,
+integers and floats become numbers, everything else is a string.
+Force a literal string by quoting: `?param.code="200"` matches the
+JSON string, `?param.code=200` matches the number.
+
+Allowed `has=` columns: `request_params`, `request_headers`,
+`response_result`, `response_error`, `notifications`, `replayed_from`.
+
+### NDJSON export
+
+`/api/v1/portal/audit/export?format=jsonl` streams summary rows as
+newline-delimited JSON. One event per line, ordered as `/events`
+returns them. Use for offline analysis or backups:
+
+```bash
+# All errors from the last 24h, piped through jq
+curl -H "X-API-Key: $KEY" \
+  "$BASE/api/v1/portal/audit/export?success=false&from=$(date -u -v-24H +%FT%TZ)" \
+  | jq -r '.tool_name + "\t" + .error_message'
+```
+
+The export omits the captured `audit_payloads` row from each line; if
+you need the full envelope, follow up with
+`/audit/events/{id}` per event. The endpoint caps at 100,000 rows
+per request; tighten the filter window for larger sets.
 
 All of these accept either the session cookie (browser) or
 `X-API-Key` / `Authorization: Bearer`.

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -49,11 +49,30 @@ Behind the cookie or `X-API-Key` / `Authorization: Bearer`.
 | `GET` | `/api/v1/portal/instructions` | The `server.instructions` text the MCP server hands to clients at initialize time. |
 | `GET` | `/api/v1/portal/tools` | List of `{name, group, description, input_schema}` for every registered tool. |
 | `GET` | `/api/v1/portal/tools/{name}` | Same shape, single tool. |
-| `GET` | `/api/v1/portal/audit/events` | Paginated audit events. Query: `from`, `to` (RFC 3339), `tool`, `user`, `session`, `success`, `q`, `limit`, `offset`. |
+| `GET` | `/api/v1/portal/audit/events` | Paginated audit events. Query: `from`, `to` (RFC 3339), `tool`, `user`, `session`, `success`, `q`, `limit`, `offset`, plus the JSONB filters described below. |
+| `GET` | `/api/v1/portal/audit/events/{id}` | Single event by id (UUID); includes the captured payload row when present. 400 on a non-UUID id, 404 when the event isn't recorded. |
+| `GET` | `/api/v1/portal/audit/export` | NDJSON stream of summary rows for a filter. `format=jsonl` (default) is the only supported format. Same filter surface as `/events`. Capped at 100,000 rows per request. |
 | `GET` | `/api/v1/portal/audit/timeseries` | Bucketed counts. Query: `from`, `to`, `bucket` (Go duration). |
 | `GET` | `/api/v1/portal/audit/breakdown` | Group-by aggregations. Query: `by` (`tool`/`user`/`success`/`auth_type`). |
 | `GET` | `/api/v1/portal/dashboard` | 1-hour stats + recent activity. |
 | `GET` | `/api/v1/portal/wellknown` | Pretty rendering of the protected-resource metadata. |
+
+### JSONB path filters
+
+`/audit/events` and `/audit/export` accept additional query parameters that compile to JSONB containment predicates against the `audit_payloads` sibling row. Filters are AND-combined with each other and with the indexed-column filters above.
+
+| Syntax | Compiles to | Example |
+| --- | --- | --- |
+| `param.<dotted.path>=<value>` | `audit_payloads.request_params @> {"<path>": <value>}` | `?param.user.id=alice` |
+| `response.<dotted.path>=<value>` | `audit_payloads.response_result @> {"<path>": <value>}` | `?response.isError=true` |
+| `header.<name>=<value>` | `audit_payloads.request_headers @> {"<name>": ["<value>"]}` | `?header.User-Agent=curl/8.0` |
+| `has=<column>` | `audit_payloads.<column> IS NOT NULL` | `?has=response_error` |
+
+Allowed `has=` columns: `request_params`, `request_headers`, `response_result`, `response_error`, `notifications`, `replayed_from`. Anything else is silently dropped.
+
+**Value type detection.** Bare values are type-detected before the containment doc is built: `true` / `false` become JSON booleans, integers and floats become numbers, everything else is a string. Force a literal string with quotes: `?param.code="200"` matches the JSON string `"200"`, while `?param.code=200` matches the JSON number `200`. The same rule applies to `response.*` and `header.*`.
+
+**Index use.** The `request_params` and `response_result` columns carry `jsonb_path_ops` GIN indexes; the `@>` operator hits them directly. `request_headers` is unindexed today, so `header.*` filters scan the matching subset and are best paired with a time-range filter. The `has=` filter is a NOT-NULL check on a stored boolean / nullable column, no index needed.
 
 ## Admin API (mutating)
 

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -70,7 +70,11 @@ Behind the cookie or `X-API-Key` / `Authorization: Bearer`.
 
 Allowed `has=` columns: `request_params`, `request_headers`, `response_result`, `response_error`, `notifications`, `replayed_from`. Anything else is silently dropped.
 
-**Value type detection.** Bare values are type-detected before the containment doc is built: `true` / `false` become JSON booleans, integers and floats become numbers, everything else is a string. Force a literal string with quotes: `?param.code="200"` matches the JSON string `"200"`, while `?param.code=200` matches the JSON number `200`. The same rule applies to `response.*` and `header.*`.
+**Value type detection.** Bare values on `param.*` and `response.*` filters are type-detected before the containment doc is built: `true` / `false` become JSON booleans, integers and floats become numbers, everything else is a string. Force a literal string with quotes: `?param.code="200"` matches the JSON string `"200"`, while `?param.code=200` matches the JSON number `200`. **Header values** (`header.*`) are always treated as strings since HTTP header values are strings on the wire; type detection does not apply there.
+
+**Header name canonicalization.** `header.<name>` canonicalizes the header name to the standard Go form before matching, so `?header.user-agent=curl/8.0` matches the same row as `?header.User-Agent=curl/8.0`.
+
+**Empty-segment paths.** `?param.a..b=v` (a path with an empty segment) cannot match any real payload and is silently dropped at parse time.
 
 **Index use.** The `request_params` and `response_result` columns carry `jsonb_path_ops` GIN indexes; the `@>` operator hits them directly. `request_headers` is unindexed today, so `header.*` filters scan the matching subset and are best paired with a time-range filter. The `has=` filter is a NOT-NULL check on a stored boolean / nullable column, no index needed.
 

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -65,18 +65,20 @@ Behind the cookie or `X-API-Key` / `Authorization: Bearer`.
 | --- | --- | --- |
 | `param.<dotted.path>=<value>` | `audit_payloads.request_params @> {"<path>": <value>}` | `?param.user.id=alice` |
 | `response.<dotted.path>=<value>` | `audit_payloads.response_result @> {"<path>": <value>}` | `?response.isError=true` |
-| `header.<name>=<value>` | `audit_payloads.request_headers @> {"<name>": ["<value>"]}` | `?header.User-Agent=curl/8.0` |
-| `has=<column>` | `audit_payloads.<column> IS NOT NULL` | `?has=response_error` |
+| `header.<name>=<value>` | `audit_payloads.request_headers @> {"<name>": ["<value>"]}` (single-segment name only) | `?header.User-Agent=curl/8.0` |
+| `has=<column>` | `audit_payloads.<column>` is `IS NOT NULL` and the column's text representation is not one of `'{}'`, `'[]'`, `'null'`, or `''` | `?has=response_error` |
 
-Allowed `has=` columns: `request_params`, `request_headers`, `response_result`, `response_error`, `notifications`, `replayed_from`. Anything else is silently dropped.
+Allowed `has=` columns: `request_params`, `request_headers`, `response_result`, `response_error`, `notifications`, `replayed_from`. Anything else is silently dropped. Note: a JSONB column literally storing the JSON string `""` (rendered as `'""'::text`, four characters) does pass the filter; the exclusion list is canonical empty containers and an empty TEXT column, not "all logically empty values."
 
 **Value type detection.** Bare values on `param.*` and `response.*` filters are type-detected before the containment doc is built: `true` / `false` become JSON booleans, integers and floats become numbers, everything else is a string. Force a literal string with quotes: `?param.code="200"` matches the JSON string `"200"`, while `?param.code=200` matches the JSON number `200`. **Header values** (`header.*`) are always treated as strings since HTTP header values are strings on the wire; type detection does not apply there.
 
 **Header name canonicalization.** `header.<name>` canonicalizes the header name to the standard Go form before matching, so `?header.user-agent=curl/8.0` matches the same row as `?header.User-Agent=curl/8.0`.
 
+**Header paths must be a single segment.** `?header.X-Foo.bar=v` is silently dropped at parse time; HTTP headers are flat name → values, no nesting. Use `param.*` or `response.*` for nested-path matches.
+
 **Empty-segment paths.** `?param.a..b=v` (a path with an empty segment) cannot match any real payload and is silently dropped at parse time.
 
-**Index use.** The `request_params` and `response_result` columns carry `jsonb_path_ops` GIN indexes; the `@>` operator hits them directly. `request_headers` is unindexed today, so `header.*` filters scan the matching subset and are best paired with a time-range filter. The `has=` filter is a NOT-NULL check on a stored boolean / nullable column, no index needed.
+**Index use.** The `request_params` and `response_result` columns carry `jsonb_path_ops` GIN indexes; the `@>` operator hits them directly. `request_headers` is unindexed today, so `header.*` filters scan the matching subset and are best paired with a time-range filter. The `has=` filter is a NOT-NULL plus non-empty-content check on a JSONB or TEXT column; the planner can use a partial index on the column when present, otherwise it scans.
 
 ## Admin API (mutating)
 

--- a/pkg/audit/async.go
+++ b/pkg/audit/async.go
@@ -109,15 +109,19 @@ func (a *AsyncLogger) GetPayload(ctx context.Context, eventID string) (*Payload,
 }
 
 // Stream delegates to the inner Logger when it implements StreamingLogger.
-// Falls back to a buffered Query when not, capped at the Limit on f
-// (or a default 10000) so the export endpoint can still serve a
-// bounded result without unbounded memory.
+// Falls back to a buffered Query() call capped at MaxQueryLimit when not,
+// so a Logger that lacks streaming still produces a bounded result.
+//
+// The fallback cap matches the underlying-backend cap (audit.MaxQueryLimit)
+// so a wrapper can't promise N rows and have the backend silently deliver
+// fewer. Callers needing more than MaxQueryLimit must wire a Logger that
+// implements StreamingLogger directly.
 func (a *AsyncLogger) Stream(ctx context.Context, f QueryFilter, fn func(Event) error) error {
 	if sl, ok := a.inner.(StreamingLogger); ok {
 		return sl.Stream(ctx, f, fn)
 	}
-	if f.Limit <= 0 {
-		f.Limit = 10000
+	if f.Limit <= 0 || f.Limit > MaxQueryLimit {
+		f.Limit = MaxQueryLimit
 	}
 	evs, err := a.inner.Query(ctx, f)
 	if err != nil {

--- a/pkg/audit/async.go
+++ b/pkg/audit/async.go
@@ -112,14 +112,19 @@ func (a *AsyncLogger) GetPayload(ctx context.Context, eventID string) (*Payload,
 // Falls back to a buffered Query() call capped at MaxQueryLimit when not,
 // so a Logger that lacks streaming still produces a bounded result.
 //
-// The fallback cap matches the underlying-backend cap (audit.MaxQueryLimit)
-// so a wrapper can't promise N rows and have the backend silently deliver
-// fewer. Callers needing more than MaxQueryLimit must wire a Logger that
+// The fallback enforces the cap inside this method, not by trusting the
+// inner Query() to honor f.Limit, because some Logger implementations
+// (test fakes, custom backends) ignore Limit. Stop iterating after
+// MaxQueryLimit events regardless of how many inner returned.
+//
+// Callers needing more than MaxQueryLimit must wire a Logger that
 // implements StreamingLogger directly.
 func (a *AsyncLogger) Stream(ctx context.Context, f QueryFilter, fn func(Event) error) error {
 	if sl, ok := a.inner.(StreamingLogger); ok {
 		return sl.Stream(ctx, f, fn)
 	}
+	// Set f.Limit as a hint for backends that honor it; we don't rely
+	// on it. The hard cap below is the source of truth.
 	if f.Limit <= 0 || f.Limit > MaxQueryLimit {
 		f.Limit = MaxQueryLimit
 	}
@@ -127,7 +132,10 @@ func (a *AsyncLogger) Stream(ctx context.Context, f QueryFilter, fn func(Event) 
 	if err != nil {
 		return err
 	}
-	for _, ev := range evs {
+	for i, ev := range evs {
+		if i >= MaxQueryLimit {
+			return nil
+		}
 		if err := fn(ev); err != nil {
 			return err
 		}

--- a/pkg/audit/async.go
+++ b/pkg/audit/async.go
@@ -108,6 +108,29 @@ func (a *AsyncLogger) GetPayload(ctx context.Context, eventID string) (*Payload,
 	return pl.GetPayload(ctx, eventID)
 }
 
+// Stream delegates to the inner Logger when it implements StreamingLogger.
+// Falls back to a buffered Query when not, capped at the Limit on f
+// (or a default 10000) so the export endpoint can still serve a
+// bounded result without unbounded memory.
+func (a *AsyncLogger) Stream(ctx context.Context, f QueryFilter, fn func(Event) error) error {
+	if sl, ok := a.inner.(StreamingLogger); ok {
+		return sl.Stream(ctx, f, fn)
+	}
+	if f.Limit <= 0 {
+		f.Limit = 10000
+	}
+	evs, err := a.inner.Query(ctx, f)
+	if err != nil {
+		return err
+	}
+	for _, ev := range evs {
+		if err := fn(ev); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Close stops accepting new events and waits for the queue to drain.
 func (a *AsyncLogger) Close() {
 	a.stopOnce.Do(func() { close(a.stop) })
@@ -176,4 +199,9 @@ func (NoopLogger) Breakdown(context.Context, time.Time, time.Time, string) ([]Br
 // Stats returns zeroed stats.
 func (NoopLogger) Stats(context.Context, time.Time, time.Time) (Stats, error) {
 	return Stats{}, nil
+}
+
+// Stream is a no-op: the noop logger has nothing to iterate.
+func (NoopLogger) Stream(context.Context, QueryFilter, func(Event) error) error {
+	return nil
 }

--- a/pkg/audit/async_test.go
+++ b/pkg/audit/async_test.go
@@ -104,6 +104,57 @@ func TestAsyncLogger_DropsWhenFull(t *testing.T) {
 	}
 }
 
+func TestAsyncLogger_StreamFallback_NonStreamingInner(t *testing.T) {
+	// fakeLogger above does NOT implement StreamingLogger (no Stream
+	// method). AsyncLogger.Stream must fall back to a bounded Query()
+	// rather than panic or no-op. Documented as best-effort, capped
+	// at MaxQueryLimit; assert events flow through and the cap holds.
+	inner := &fakeLogger{}
+	for i := 0; i < 5; i++ {
+		inner.events = append(inner.events, Event{ToolName: "t", ID: string(rune('a' + i))})
+	}
+	a := NewAsyncLogger(inner, 16, time.Second, quietLogger())
+	defer a.Close()
+
+	count := 0
+	if err := a.Stream(context.Background(), QueryFilter{}, func(Event) error {
+		count++
+		return nil
+	}); err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	if count != 5 {
+		t.Errorf("count = %d, want 5", count)
+	}
+}
+
+func TestAsyncLogger_StreamFallback_ClampsToMaxQueryLimit(t *testing.T) {
+	// fakeLogger does NOT implement StreamingLogger AND does not honor
+	// QueryFilter.Limit (Query returns all events). The Stream fallback
+	// must enforce the MaxQueryLimit cap itself rather than trusting
+	// the inner backend to do it. Push more than the cap; assert fn
+	// is invoked exactly MaxQueryLimit times.
+	inner := &fakeLogger{}
+	const stored = MaxQueryLimit + 500
+	for i := 0; i < stored; i++ {
+		inner.events = append(inner.events, Event{ToolName: "t"})
+	}
+	a := NewAsyncLogger(inner, 16, time.Second, quietLogger())
+	defer a.Close()
+
+	count := 0
+	if err := a.Stream(context.Background(), QueryFilter{}, func(Event) error {
+		count++
+		return nil
+	}); err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	if count != MaxQueryLimit {
+		t.Errorf("count = %d, want MaxQueryLimit (%d): wrapper failed to enforce cap when inner ignored Limit",
+			count, MaxQueryLimit)
+	}
+}
+
 func TestAsyncLogger_DelegatesReadMethods(t *testing.T) {
 	inner := &fakeLogger{events: []Event{{ToolName: "x"}, {ToolName: "y"}}}
 	a := NewAsyncLogger(inner, 16, time.Second, quietLogger())

--- a/pkg/audit/jsonfilter.go
+++ b/pkg/audit/jsonfilter.go
@@ -47,12 +47,6 @@ func JSONFilterToContainment(path []string, value any) any {
 	return cur
 }
 
-// JSONFilterToBytes marshals JSONFilterToContainment(path, value) to
-// JSON bytes, suitable to pass as a $N::jsonb argument.
-func JSONFilterToBytes(path []string, value any) ([]byte, error) {
-	return json.Marshal(JSONFilterToContainment(path, value))
-}
-
 // MatchJSONPath reports whether m contains a value at the given dotted
 // path equal to want, using the same type detection as
 // ParseJSONFilterValue. Used by MemoryLogger's filter loop. Comparison
@@ -110,13 +104,19 @@ func numericEq(a float64, b any) bool {
 		return a == bv
 	case float32:
 		return a == float64(bv)
-	case int64:
+	case int8:
+		return a == float64(bv)
+	case int16:
 		return a == float64(bv)
 	case int32:
 		return a == float64(bv)
+	case int64:
+		return a == float64(bv)
 	case int:
 		return a == float64(bv)
-	case uint:
+	case uint8:
+		return a == float64(bv)
+	case uint16:
 		return a == float64(bv)
 	case uint32:
 		return a == float64(bv)
@@ -125,6 +125,8 @@ func numericEq(a float64, b any) bool {
 		// best we can do without bigint, and audit numbers are nowhere
 		// near 2^53.
 		return a == float64(bv)
+	case uint:
+		return a == float64(bv)
 	case json.Number:
 		bf, _ := bv.Float64()
 		return a == bf
@@ -132,22 +134,32 @@ func numericEq(a float64, b any) bool {
 	return false
 }
 
-// IsAllowedHasKey reports whether key is one of AllowedHasKeys.
+// IsAllowedHasKey reports whether key is an allowlisted has= column.
+// Implemented as a closed switch (not a slice iteration) so the
+// AllowedHasKeys exported var cannot be mutated by an importing package
+// to widen what gets spliced into the verbatim SQL column reference in
+// buildSelect. The slice stays exported for documentation generators
+// and reflection callers; the gate is the function.
 func IsAllowedHasKey(key string) bool {
-	for _, k := range AllowedHasKeys {
-		if k == key {
-			return true
-		}
+	switch key {
+	case "request_params",
+		"request_headers",
+		"response_result",
+		"response_error",
+		"notifications",
+		"replayed_from":
+		return true
 	}
 	return false
 }
 
-// IsAllowedJSONSource reports whether src is one of AllowedJSONSources.
+// IsAllowedJSONSource reports whether src is an allowlisted source.
+// Closed switch for the same reason as IsAllowedHasKey: defense against
+// mutation of the exported AllowedJSONSources slice.
 func IsAllowedJSONSource(src string) bool {
-	for _, s := range AllowedJSONSources {
-		if s == src {
-			return true
-		}
+	switch src {
+	case "param", "response", "header":
+		return true
 	}
 	return false
 }

--- a/pkg/audit/jsonfilter.go
+++ b/pkg/audit/jsonfilter.go
@@ -108,9 +108,22 @@ func numericEq(a float64, b any) bool {
 	switch bv := b.(type) {
 	case float64:
 		return a == bv
+	case float32:
+		return a == float64(bv)
 	case int64:
 		return a == float64(bv)
+	case int32:
+		return a == float64(bv)
 	case int:
+		return a == float64(bv)
+	case uint:
+		return a == float64(bv)
+	case uint32:
+		return a == float64(bv)
+	case uint64:
+		// Lossy at very large values; for filter-equality this is the
+		// best we can do without bigint, and audit numbers are nowhere
+		// near 2^53.
 		return a == float64(bv)
 	case json.Number:
 		bf, _ := bv.Float64()

--- a/pkg/audit/jsonfilter.go
+++ b/pkg/audit/jsonfilter.go
@@ -1,0 +1,151 @@
+package audit
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+)
+
+// ParseJSONFilterValue type-detects a URL-supplied string into a Go
+// value suitable for JSON containment matching.
+//
+// Detection order: bool ("true"/"false"), int64, float64, plain string.
+// Quoted forms (`"42"`) force string. This keeps `?response.isError=true`
+// matching JSON true rather than the string "true", while letting an
+// operator who actually wants the string write `?param.code="200"`.
+func ParseJSONFilterValue(s string) any {
+	if s == "true" {
+		return true
+	}
+	if s == "false" {
+		return false
+	}
+	// Quoted force-string: "abc" -> abc as string.
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		return s[1 : len(s)-1]
+	}
+	if i, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return i
+	}
+	if f, err := strconv.ParseFloat(s, 64); err == nil {
+		return f
+	}
+	return s
+}
+
+// JSONFilterToContainment turns Path=[a,b,c], Value=v into the JSON
+// document {"a": {"b": {"c": v}}} suitable for Postgres @> containment
+// and for the MemoryLogger's nested map walk. Empty Path returns just v.
+func JSONFilterToContainment(path []string, value any) any {
+	if len(path) == 0 {
+		return value
+	}
+	cur := any(value)
+	for i := len(path) - 1; i >= 0; i-- {
+		cur = map[string]any{path[i]: cur}
+	}
+	return cur
+}
+
+// JSONFilterToBytes marshals JSONFilterToContainment(path, value) to
+// JSON bytes, suitable to pass as a $N::jsonb argument.
+func JSONFilterToBytes(path []string, value any) ([]byte, error) {
+	return json.Marshal(JSONFilterToContainment(path, value))
+}
+
+// MatchJSONPath reports whether m contains a value at the given dotted
+// path equal to want, using the same type detection as
+// ParseJSONFilterValue. Used by MemoryLogger's filter loop. Comparison
+// is JSON-semantic (number widens int<->float; bool exact; string exact).
+func MatchJSONPath(m map[string]any, path []string, want any) bool {
+	if len(path) == 0 {
+		return jsonEqual(m, want)
+	}
+	cur := any(m)
+	for _, seg := range path {
+		next, ok := cur.(map[string]any)
+		if !ok {
+			return false
+		}
+		v, present := next[seg]
+		if !present {
+			return false
+		}
+		cur = v
+	}
+	return jsonEqual(cur, want)
+}
+
+// jsonEqual returns true when a and b are equal under JSON semantics.
+// Numbers widen across int / float; strings, bools, and exact equality
+// otherwise. Maps and slices are compared via deep marshal-then-equal,
+// which is rare for filter values (almost always scalars).
+func jsonEqual(a, b any) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	switch av := a.(type) {
+	case bool:
+		bv, ok := b.(bool)
+		return ok && av == bv
+	case string:
+		bv, ok := b.(string)
+		return ok && av == bv
+	case float64:
+		return numericEq(av, b)
+	case int64:
+		return numericEq(float64(av), b)
+	case int:
+		return numericEq(float64(av), b)
+	}
+	// Fall back to JSON round-trip for compound types.
+	ab, _ := json.Marshal(a)
+	bb, _ := json.Marshal(b)
+	return string(ab) == string(bb)
+}
+
+func numericEq(a float64, b any) bool {
+	switch bv := b.(type) {
+	case float64:
+		return a == bv
+	case int64:
+		return a == float64(bv)
+	case int:
+		return a == float64(bv)
+	case json.Number:
+		bf, _ := bv.Float64()
+		return a == bf
+	}
+	return false
+}
+
+// IsAllowedHasKey reports whether key is one of AllowedHasKeys.
+func IsAllowedHasKey(key string) bool {
+	for _, k := range AllowedHasKeys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
+
+// IsAllowedJSONSource reports whether src is one of AllowedJSONSources.
+func IsAllowedJSONSource(src string) bool {
+	for _, s := range AllowedJSONSources {
+		if s == src {
+			return true
+		}
+	}
+	return false
+}
+
+// SplitJSONPath splits a dotted path "a.b.c" into ["a","b","c"]. Empty
+// input returns a nil slice. A trailing/leading dot is treated as an
+// empty segment, which won't match anything; that's fine since the
+// HTTP layer rejects empty segments before this is called.
+func SplitJSONPath(s string) []string {
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, ".")
+}

--- a/pkg/audit/jsonfilter_test.go
+++ b/pkg/audit/jsonfilter_test.go
@@ -1,0 +1,130 @@
+package audit
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseJSONFilterValue(t *testing.T) {
+	cases := []struct {
+		in   string
+		want any
+	}{
+		{"true", true},
+		{"false", false},
+		{"42", int64(42)},
+		{"-7", int64(-7)},
+		{"3.14", 3.14},
+		{`"42"`, "42"},         // forced string
+		{`"true"`, "true"},     // forced string
+		{`"hello"`, "hello"},   // forced string
+		{"hello", "hello"},     // plain string
+		{"", ""},               // empty stays empty (HTTP layer should reject)
+		{"alice@x", "alice@x"}, // @ is not numeric, stays string
+	}
+	for _, c := range cases {
+		got := ParseJSONFilterValue(c.in)
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("ParseJSONFilterValue(%q) = %v (%T), want %v (%T)",
+				c.in, got, got, c.want, c.want)
+		}
+	}
+}
+
+func TestJSONFilterToContainment(t *testing.T) {
+	cases := []struct {
+		path  []string
+		value any
+		want  any
+	}{
+		{nil, "v", "v"},
+		{[]string{}, 42, 42},
+		{[]string{"a"}, "v", map[string]any{"a": "v"}},
+		{[]string{"a", "b"}, true, map[string]any{"a": map[string]any{"b": true}}},
+		{[]string{"x", "y", "z"}, int64(1),
+			map[string]any{"x": map[string]any{"y": map[string]any{"z": int64(1)}}}},
+	}
+	for _, c := range cases {
+		got := JSONFilterToContainment(c.path, c.value)
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("JSONFilterToContainment(%v, %v) = %v, want %v",
+				c.path, c.value, got, c.want)
+		}
+	}
+}
+
+func TestMatchJSONPath(t *testing.T) {
+	doc := map[string]any{
+		"top":     "leaf",
+		"flag":    true,
+		"count":   float64(3),
+		"countI":  int64(3),
+		"nested":  map[string]any{"deep": map[string]any{"x": "y"}},
+		"isError": false,
+	}
+	cases := []struct {
+		path []string
+		want any
+		ok   bool
+	}{
+		{[]string{"top"}, "leaf", true},
+		{[]string{"top"}, "nope", false},
+		{[]string{"flag"}, true, true},
+		{[]string{"flag"}, false, false},
+		{[]string{"count"}, int64(3), true}, // float<->int widen
+		{[]string{"countI"}, float64(3), true},
+		{[]string{"nested", "deep", "x"}, "y", true},
+		{[]string{"nested", "deep", "x"}, "z", false},
+		{[]string{"nested", "missing"}, "y", false},
+		{[]string{"isError"}, false, true},
+		{[]string{"isError"}, true, false},
+	}
+	for _, c := range cases {
+		got := MatchJSONPath(doc, c.path, c.want)
+		if got != c.ok {
+			t.Errorf("MatchJSONPath(%v, %v) = %v, want %v",
+				c.path, c.want, got, c.ok)
+		}
+	}
+}
+
+func TestMatchJSONPath_NonMapTraversal(t *testing.T) {
+	// A path that descends past a non-map value should fail rather than
+	// panic. Operators have no way to send such a path today (the HTTP
+	// layer rejects before we get here), but the helper is conservative.
+	doc := map[string]any{"a": "scalar"}
+	if MatchJSONPath(doc, []string{"a", "b"}, "scalar") {
+		t.Error("expected false: cannot descend past scalar")
+	}
+}
+
+func TestSplitJSONPath(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"a", []string{"a"}},
+		{"a.b.c", []string{"a", "b", "c"}},
+		{"User-Agent", []string{"User-Agent"}},
+	}
+	for _, c := range cases {
+		got := SplitJSONPath(c.in)
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("SplitJSONPath(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestIsAllowedHasKey(t *testing.T) {
+	for _, k := range AllowedHasKeys {
+		if !IsAllowedHasKey(k) {
+			t.Errorf("IsAllowedHasKey(%q) = false, want true (in allow list)", k)
+		}
+	}
+	for _, k := range []string{"", "events", "id", "DROP TABLE"} {
+		if IsAllowedHasKey(k) {
+			t.Errorf("IsAllowedHasKey(%q) = true, want false", k)
+		}
+	}
+}

--- a/pkg/audit/jsonfilter_test.go
+++ b/pkg/audit/jsonfilter_test.go
@@ -112,12 +112,16 @@ func TestNumericEq_TypeSurface(t *testing.T) {
 		{"float64 eq", 3, float64(3), true},
 		{"float64 ne", 3, float64(4), false},
 		{"float32", 3, float32(3), true},
-		{"int64", 3, int64(3), true},
+		{"int8", 3, int8(3), true},
+		{"int16", 3, int16(3), true},
 		{"int32", 3, int32(3), true},
+		{"int64", 3, int64(3), true},
 		{"int", 3, 3, true},
-		{"uint", 3, uint(3), true},
+		{"uint8", 3, uint8(3), true},
+		{"uint16", 3, uint16(3), true},
 		{"uint32", 3, uint32(3), true},
 		{"uint64", 3, uint64(3), true},
+		{"uint", 3, uint(3), true},
 		{"json.Number", 3.5, json.Number("3.5"), true},
 		{"unsupported type", 3, "3", false},
 	}
@@ -156,6 +160,70 @@ func TestIsAllowedHasKey(t *testing.T) {
 	for _, k := range []string{"", "events", "id", "DROP TABLE"} {
 		if IsAllowedHasKey(k) {
 			t.Errorf("IsAllowedHasKey(%q) = true, want false", k)
+		}
+	}
+}
+
+func TestAllowList_FunctionAndSliceAgree(t *testing.T) {
+	// IsAllowedHasKey and IsAllowedJSONSource are implemented as closed
+	// switches; AllowedHasKeys and AllowedJSONSources are exported
+	// slices for documentation. Both must agree in BOTH directions:
+	// every slice entry must be allowed by the function, and the
+	// function must not allow anything outside the slice (within a
+	// candidate set wide enough to catch typos / additions).
+	//
+	// The candidate set lists every column that could plausibly be
+	// added to has= and every source that could plausibly be added to
+	// the JSON-path syntax; if a future change widens the function but
+	// forgets the slice (or vice versa), this test surfaces the drift.
+
+	// Has keys.
+	for _, k := range AllowedHasKeys {
+		if !IsAllowedHasKey(k) {
+			t.Errorf("AllowedHasKeys contains %q but IsAllowedHasKey rejects it", k)
+		}
+	}
+	candidateColumns := append([]string{}, AllowedHasKeys...)
+	candidateColumns = append(candidateColumns,
+		"event_id", "ts", "captured_at", "request_size_bytes",
+		"response_size_bytes", "request_truncated", "response_truncated",
+		"jsonrpc_method", "jsonrpc_id", "request_method", "request_path",
+		"request_remote_addr", "notifications_truncated",
+	)
+	for _, k := range candidateColumns {
+		want := false
+		for _, allowed := range AllowedHasKeys {
+			if k == allowed {
+				want = true
+				break
+			}
+		}
+		if got := IsAllowedHasKey(k); got != want {
+			t.Errorf("IsAllowedHasKey(%q) = %v, want %v (slice/function disagree)", k, got, want)
+		}
+	}
+
+	// JSON sources.
+	for _, s := range AllowedJSONSources {
+		if !IsAllowedJSONSource(s) {
+			t.Errorf("AllowedJSONSources contains %q but IsAllowedJSONSource rejects it", s)
+		}
+	}
+	for _, s := range append([]string{}, AllowedJSONSources...) {
+		want := false
+		for _, a := range AllowedJSONSources {
+			if s == a {
+				want = true
+				break
+			}
+		}
+		if got := IsAllowedJSONSource(s); got != want {
+			t.Errorf("IsAllowedJSONSource(%q) = %v, want %v", s, got, want)
+		}
+	}
+	for _, s := range []string{"", "params", "headers", "result", "PARAM", "Param"} {
+		if IsAllowedJSONSource(s) {
+			t.Errorf("IsAllowedJSONSource(%q) = true, want false", s)
 		}
 	}
 }

--- a/pkg/audit/jsonfilter_test.go
+++ b/pkg/audit/jsonfilter_test.go
@@ -1,6 +1,7 @@
 package audit
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 )
@@ -95,6 +96,36 @@ func TestMatchJSONPath_NonMapTraversal(t *testing.T) {
 	doc := map[string]any{"a": "scalar"}
 	if MatchJSONPath(doc, []string{"a", "b"}, "scalar") {
 		t.Error("expected false: cannot descend past scalar")
+	}
+}
+
+func TestNumericEq_TypeSurface(t *testing.T) {
+	// numericEq compares the float64 left side against arbitrary right
+	// types. Cover each case so a future signature change can't drop a
+	// type silently.
+	cases := []struct {
+		name string
+		a    float64
+		b    any
+		want bool
+	}{
+		{"float64 eq", 3, float64(3), true},
+		{"float64 ne", 3, float64(4), false},
+		{"float32", 3, float32(3), true},
+		{"int64", 3, int64(3), true},
+		{"int32", 3, int32(3), true},
+		{"int", 3, 3, true},
+		{"uint", 3, uint(3), true},
+		{"uint32", 3, uint32(3), true},
+		{"uint64", 3, uint64(3), true},
+		{"json.Number", 3.5, json.Number("3.5"), true},
+		{"unsupported type", 3, "3", false},
+	}
+	for _, c := range cases {
+		got := numericEq(c.a, c.b)
+		if got != c.want {
+			t.Errorf("%s: numericEq(%v, %v) = %v, want %v", c.name, c.a, c.b, got, c.want)
+		}
 	}
 }
 

--- a/pkg/audit/logger.go
+++ b/pkg/audit/logger.go
@@ -104,7 +104,7 @@ type QueryFilter struct {
 
 	// JSONFilters narrow by JSONB content of audit_payloads.
 	// Each filter checks that the value at Path inside Source equals
-	// Value (with light type detection on Value, see ParseJSONValue).
+	// Value (with light type detection on Value, see ParseJSONFilterValue).
 	JSONFilters []JSONPathFilter
 
 	// HasKeys narrows to events whose audit_payloads row has the named

--- a/pkg/audit/logger.go
+++ b/pkg/audit/logger.go
@@ -25,6 +25,17 @@ type PayloadLogger interface {
 	GetPayload(ctx context.Context, eventID string) (*Payload, error)
 }
 
+// StreamingLogger is the optional capability for cursor-style iteration
+// over a filtered event set. The NDJSON export endpoint type-asserts
+// for it so we don't load the entire result set into memory.
+//
+// fn is called once per event; returning a non-nil error stops the
+// iteration and bubbles back to Stream's caller. Loggers that don't
+// implement this interface fall back to Query() with a hard cap.
+type StreamingLogger interface {
+	Stream(ctx context.Context, f QueryFilter, fn func(Event) error) error
+}
+
 // TimePoint is one bucket of an audit time series.
 type TimePoint struct {
 	Time     time.Time `json:"time"`
@@ -52,7 +63,13 @@ type Stats struct {
 	UniqueTools    int64   `json:"unique_tools"`
 }
 
-// QueryFilter narrows audit_events results.
+// QueryFilter narrows audit_events results. Filters are AND-combined.
+//
+// JSONFilters and HasKeys reach into the audit_payloads sibling row.
+// The Postgres store compiles them to JSONB containment / column-not-null
+// predicates against audit_payloads via EXISTS subqueries; the
+// MemoryLogger evaluates them in Go against Event.Payload. Loggers that
+// don't carry payloads (NoopLogger) ignore them.
 type QueryFilter struct {
 	From      time.Time
 	To        time.Time
@@ -65,4 +82,45 @@ type QueryFilter struct {
 	Limit     int
 	Offset    int
 	OrderDesc bool
+
+	// JSONFilters narrow by JSONB content of audit_payloads.
+	// Each filter checks that the value at Path inside Source equals
+	// Value (with light type detection on Value, see ParseJSONValue).
+	JSONFilters []JSONPathFilter
+
+	// HasKeys narrows to events whose audit_payloads row has the named
+	// payload column populated (NOT NULL). Allowed keys come from
+	// AllowedHasKeys; anything else is rejected at parse time.
+	HasKeys []string
 }
+
+// JSONPathFilter narrows by a value inside an audit_payloads JSONB column.
+//
+// Source picks the column: "param" -> request_params, "response" ->
+// response_result, "header" -> request_headers. Path is the dotted
+// path inside that column ("user.id"); Value is the URL string,
+// type-detected at compile time so ?response.isError=true matches the
+// JSON literal true rather than the string "true".
+type JSONPathFilter struct {
+	Source string
+	Path   []string
+	Value  string
+}
+
+// AllowedHasKeys is the closed set of payload-column names accepted by
+// the ?has=<key> query parameter. Restricted to columns the audit
+// middleware actually populates today; new columns must be added here
+// before they're queryable. Strings (not constants) so the HTTP layer
+// can validate user input directly.
+var AllowedHasKeys = []string{
+	"request_params",
+	"request_headers",
+	"response_result",
+	"response_error",
+	"notifications",
+	"replayed_from",
+}
+
+// AllowedJSONSources is the closed set of {Source} values JSONPathFilter
+// accepts; any other value is rejected at parse time.
+var AllowedJSONSources = []string{"param", "response", "header"}

--- a/pkg/audit/logger.go
+++ b/pkg/audit/logger.go
@@ -29,12 +29,31 @@ type PayloadLogger interface {
 // over a filtered event set. The NDJSON export endpoint type-asserts
 // for it so we don't load the entire result set into memory.
 //
-// fn is called once per event; returning a non-nil error stops the
-// iteration and bubbles back to Stream's caller. Loggers that don't
-// implement this interface fall back to Query() with a hard cap.
+// Semantics:
+//   - f.Limit and f.Offset are IGNORED by implementations that can
+//     truly stream (Postgres, MemoryLogger). Stream iterates the whole
+//     filtered set; the caller stops early by returning a sentinel
+//     error from fn. The export endpoint does this with its own cap.
+//   - fn is called once per event; returning a non-nil error stops the
+//     iteration and bubbles back to Stream's caller. ctx cancellation
+//     is honored at page boundaries.
+//
+// Implementations that wrap a Logger which does NOT itself implement
+// StreamingLogger (e.g. AsyncLogger over a custom non-streaming inner)
+// degrade to a single bounded Query() call capped at MaxQueryLimit;
+// such implementations can deliver fewer events than the filter would
+// match. See AsyncLogger.Stream for the fallback contract.
 type StreamingLogger interface {
 	Stream(ctx context.Context, f QueryFilter, fn func(Event) error) error
 }
+
+// MaxQueryLimit is the largest LIMIT any backend will honor on a single
+// SELECT. Larger values get silently reduced. Defined here (not in the
+// Postgres package) so AsyncLogger and any other Logger wrapper can
+// honor the same cap when falling back to Query()-driven iteration,
+// avoiding the silent-cap-mismatch where a wrapper promises N rows
+// and the underlying backend delivers fewer.
+const MaxQueryLimit = 1000
 
 // TimePoint is one bucket of an audit time series.
 type TimePoint struct {

--- a/pkg/audit/memory.go
+++ b/pkg/audit/memory.go
@@ -43,7 +43,15 @@ func (m *MemoryLogger) Query(_ context.Context, f QueryFilter) ([]Event, error) 
 		}
 		out = append(out, ev)
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Timestamp.After(out[j].Timestamp) })
+	// ts DESC, id ASC. Mirrors the Postgres store's ordering so the
+	// two backends agree under tied timestamps; without the tiebreaker,
+	// Stream pagination can duplicate or skip rows at page boundaries.
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].Timestamp.Equal(out[j].Timestamp) {
+			return out[i].Timestamp.After(out[j].Timestamp)
+		}
+		return out[i].ID < out[j].ID
+	})
 	if f.Limit > 0 && len(out) > f.Limit {
 		out = out[:f.Limit]
 	}
@@ -66,10 +74,17 @@ func (m *MemoryLogger) Count(ctx context.Context, f QueryFilter) (int64, error) 
 // return them. Used by the NDJSON export to avoid loading the full
 // result set into memory; for the in-memory logger the savings are
 // theoretical, but the contract matches the Postgres store's cursor.
+//
+// Per the StreamingLogger contract, f.Limit is ignored: Stream iterates
+// the whole filtered set, and callers that need a stop-after-N stop by
+// returning a sentinel error from fn. We strip Limit / Offset before
+// delegating to Query so the contract is honored regardless of caller.
 func (m *MemoryLogger) Stream(ctx context.Context, f QueryFilter, fn func(Event) error) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	f.Limit = 0
+	f.Offset = 0
 	evs, err := m.Query(ctx, f)
 	if err != nil {
 		return err

--- a/pkg/audit/memory.go
+++ b/pkg/audit/memory.go
@@ -62,6 +62,26 @@ func (m *MemoryLogger) Count(ctx context.Context, f QueryFilter) (int64, error) 
 	return int64(len(evs)), nil
 }
 
+// Stream calls fn once per matching event, in the same order Query would
+// return them. Used by the NDJSON export to avoid loading the full
+// result set into memory; for the in-memory logger the savings are
+// theoretical, but the contract matches the Postgres store's cursor.
+func (m *MemoryLogger) Stream(ctx context.Context, f QueryFilter, fn func(Event) error) error {
+	evs, err := m.Query(ctx, f)
+	if err != nil {
+		return err
+	}
+	for _, ev := range evs {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if err := fn(ev); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Snapshot returns a copy of all events in insertion order, for assertions.
 func (m *MemoryLogger) Snapshot() []Event {
 	m.mu.Lock()
@@ -240,6 +260,116 @@ func matchesFilter(ev Event, f QueryFilter) bool {
 	}
 	if f.Success != nil && ev.Success != *f.Success {
 		return false
+	}
+	if !matchesJSONFilters(ev, f.JSONFilters) {
+		return false
+	}
+	if !matchesHasKeys(ev, f.HasKeys) {
+		return false
+	}
+	return true
+}
+
+// matchesJSONFilters runs each JSONPathFilter against ev.Payload using
+// the same path semantics the Postgres store will compile to JSONB
+// containment. Returns false the moment any filter misses; an event
+// with no payload row fails any non-empty filter.
+func matchesJSONFilters(ev Event, fs []JSONPathFilter) bool {
+	if len(fs) == 0 {
+		return true
+	}
+	if ev.Payload == nil {
+		return false
+	}
+	for _, jf := range fs {
+		var src map[string]any
+		switch jf.Source {
+		case "param":
+			src = ev.Payload.RequestParams
+		case "response":
+			src = ev.Payload.ResponseResult
+		case "header":
+			// Headers are map[string][]string in Go but stored as JSONB
+			// objects on disk (Postgres serializes them as arrays of
+			// strings). For MemoryLogger we adapt: a path like "User-Agent"
+			// matches the first header value.
+			if ev.Payload.RequestHeaders == nil {
+				return false
+			}
+			if len(jf.Path) == 0 {
+				return false
+			}
+			values, ok := ev.Payload.RequestHeaders[jf.Path[0]]
+			if !ok || len(values) == 0 {
+				return false
+			}
+			want := ParseJSONFilterValue(jf.Value)
+			matched := false
+			for _, v := range values {
+				if jsonEqual(v, want) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				return false
+			}
+			continue
+		default:
+			return false
+		}
+		if src == nil {
+			return false
+		}
+		want := ParseJSONFilterValue(jf.Value)
+		if !MatchJSONPath(src, jf.Path, want) {
+			return false
+		}
+	}
+	return true
+}
+
+// matchesHasKeys returns false when any required has= column is missing
+// from the event's payload. AllowedHasKeys is the closed set; anything
+// else returns false (the HTTP layer should have rejected it earlier,
+// but defense in depth).
+func matchesHasKeys(ev Event, keys []string) bool {
+	if len(keys) == 0 {
+		return true
+	}
+	if ev.Payload == nil {
+		return false
+	}
+	p := ev.Payload
+	for _, k := range keys {
+		switch k {
+		case "request_params":
+			if len(p.RequestParams) == 0 {
+				return false
+			}
+		case "request_headers":
+			if len(p.RequestHeaders) == 0 {
+				return false
+			}
+		case "response_result":
+			if len(p.ResponseResult) == 0 {
+				return false
+			}
+		case "response_error":
+			if len(p.ResponseError) == 0 {
+				return false
+			}
+		case "notifications":
+			if len(p.Notifications) == 0 {
+				return false
+			}
+		case "replayed_from":
+			if p.ReplayedFrom == "" {
+				return false
+			}
+		default:
+			return false
+		}
 	}
 	return true
 }

--- a/pkg/audit/memory.go
+++ b/pkg/audit/memory.go
@@ -33,9 +33,13 @@ func (m *MemoryLogger) Log(_ context.Context, ev Event) error {
 // UserID, From, To, Success, and Limit are honored; other filter fields are
 // ignored. Sufficient for tests; the Postgres store covers the full filter
 // surface.
-func (m *MemoryLogger) Query(_ context.Context, f QueryFilter) ([]Event, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+// matchAll applies every QueryFilter predicate EXCEPT Limit/Offset and
+// returns the matching events in canonical Query order (ts DESC, id ASC).
+// Shared by Query, Count, and Stream so all three agree on filter
+// semantics and ordering regardless of pagination.
+//
+// Caller must hold m.mu.
+func (m *MemoryLogger) matchAll(f QueryFilter) []Event {
 	out := make([]Event, 0, len(m.events))
 	for _, ev := range m.events {
 		if !matchesFilter(ev, f) {
@@ -52,22 +56,43 @@ func (m *MemoryLogger) Query(_ context.Context, f QueryFilter) ([]Event, error) 
 		}
 		return out[i].ID < out[j].ID
 	})
-	if f.Limit > 0 && len(out) > f.Limit {
-		out = out[:f.Limit]
+	return out
+}
+
+// Query returns matching events ordered ts DESC, id ASC, with the
+// limit-clamp rules described inline. Calls matchAll to share filter
+// semantics with Count and Stream.
+func (m *MemoryLogger) Query(_ context.Context, f QueryFilter) ([]Event, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := m.matchAll(f)
+	// Limit-clamp rules, mirroring Postgres buildSelect:
+	//   Limit <= 0 (unset / negative) -> default page size (100)
+	//   0 < Limit <= MaxQueryLimit    -> honored as given
+	//   Limit > MaxQueryLimit         -> clamped to MaxQueryLimit
+	// Count and Stream do NOT route through here; they use matchAll
+	// directly so the page-size default doesn't truncate them.
+	limit := f.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	if limit > MaxQueryLimit {
+		limit = MaxQueryLimit
+	}
+	if len(out) > limit {
+		out = out[:limit]
 	}
 	return out, nil
 }
 
-// Count returns the number of matching events, ignoring Limit/Offset so
-// pagination metadata is correct.
-func (m *MemoryLogger) Count(ctx context.Context, f QueryFilter) (int64, error) {
-	f.Limit = 0
-	f.Offset = 0
-	evs, err := m.Query(ctx, f)
-	if err != nil {
-		return 0, err
-	}
-	return int64(len(evs)), nil
+// Count returns the number of matching events. Ignores f.Limit and
+// f.Offset so pagination metadata is correct (Postgres uses
+// SELECT count(*); MemoryLogger uses len() over matchAll). Routing
+// through Query would silently cap at the page-size default.
+func (m *MemoryLogger) Count(_ context.Context, f QueryFilter) (int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return int64(len(m.matchAll(f))), nil
 }
 
 // Stream calls fn once per matching event, in the same order Query would
@@ -75,20 +100,17 @@ func (m *MemoryLogger) Count(ctx context.Context, f QueryFilter) (int64, error) 
 // result set into memory; for the in-memory logger the savings are
 // theoretical, but the contract matches the Postgres store's cursor.
 //
-// Per the StreamingLogger contract, f.Limit is ignored: Stream iterates
-// the whole filtered set, and callers that need a stop-after-N stop by
-// returning a sentinel error from fn. We strip Limit / Offset before
-// delegating to Query so the contract is honored regardless of caller.
+// Per the StreamingLogger contract, f.Limit and f.Offset are ignored:
+// Stream iterates the whole filtered set; callers stop early by
+// returning a sentinel error from fn. Uses matchAll directly so the
+// 100-row page-size default in Query never reaches this path.
 func (m *MemoryLogger) Stream(ctx context.Context, f QueryFilter, fn func(Event) error) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	f.Limit = 0
-	f.Offset = 0
-	evs, err := m.Query(ctx, f)
-	if err != nil {
-		return err
-	}
+	m.mu.Lock()
+	evs := m.matchAll(f)
+	m.mu.Unlock()
 	for _, ev := range evs {
 		if err := ctx.Err(); err != nil {
 			return err

--- a/pkg/audit/memory.go
+++ b/pkg/audit/memory.go
@@ -67,13 +67,16 @@ func (m *MemoryLogger) Count(ctx context.Context, f QueryFilter) (int64, error) 
 // result set into memory; for the in-memory logger the savings are
 // theoretical, but the contract matches the Postgres store's cursor.
 func (m *MemoryLogger) Stream(ctx context.Context, f QueryFilter, fn func(Event) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	evs, err := m.Query(ctx, f)
 	if err != nil {
 		return err
 	}
 	for _, ev := range evs {
-		if ctx.Err() != nil {
-			return ctx.Err()
+		if err := ctx.Err(); err != nil {
+			return err
 		}
 		if err := fn(ev); err != nil {
 			return err
@@ -289,10 +292,11 @@ func matchesJSONFilters(ev Event, fs []JSONPathFilter) bool {
 		case "response":
 			src = ev.Payload.ResponseResult
 		case "header":
-			// Headers are map[string][]string in Go but stored as JSONB
-			// objects on disk (Postgres serializes them as arrays of
-			// strings). For MemoryLogger we adapt: a path like "User-Agent"
-			// matches the first header value.
+			// Headers are map[string][]string in Go and serialize to
+			// JSONB as {"Name": ["value", ...]}. Postgres-side @>
+			// containment matches when the array contains the wanted
+			// value; mirror that here by accepting a hit on any of the
+			// stored values for the named header.
 			if ev.Payload.RequestHeaders == nil {
 				return false
 			}
@@ -303,10 +307,12 @@ func matchesJSONFilters(ev Event, fs []JSONPathFilter) bool {
 			if !ok || len(values) == 0 {
 				return false
 			}
-			want := ParseJSONFilterValue(jf.Value)
+			// Header values are always strings on the wire; compare the
+			// raw filter value as a string rather than running it through
+			// ParseJSONFilterValue. Mirrors what the Postgres compiler does.
 			matched := false
 			for _, v := range values {
-				if jsonEqual(v, want) {
+				if v == jf.Value {
 					matched = true
 					break
 				}

--- a/pkg/audit/memory_test.go
+++ b/pkg/audit/memory_test.go
@@ -69,6 +69,114 @@ func TestMemoryLogger_QueryFilters(t *testing.T) {
 	}
 }
 
+func TestMemoryLogger_JSONFiltersAndHasKeys(t *testing.T) {
+	m := NewMemoryLogger()
+	now := time.Now().UTC()
+	_ = m.Log(context.Background(), Event{
+		ID: "1", ToolName: "echo", Timestamp: now, Success: true,
+		Payload: &Payload{
+			RequestParams:  map[string]any{"message": "hello", "user": map[string]any{"id": "alice"}},
+			ResponseResult: map[string]any{"isError": false},
+			RequestHeaders: map[string][]string{"User-Agent": {"curl/8.0"}},
+		},
+	})
+	_ = m.Log(context.Background(), Event{
+		ID: "2", ToolName: "echo", Timestamp: now.Add(time.Second), Success: false,
+		Payload: &Payload{
+			RequestParams:  map[string]any{"message": "world", "user": map[string]any{"id": "bob"}},
+			ResponseResult: map[string]any{"isError": true},
+			ResponseError:  map[string]any{"category": "tool", "message": "boom"},
+		},
+	})
+
+	cases := []struct {
+		name   string
+		filter QueryFilter
+		ids    []string // expected event IDs (Query order: ts DESC)
+	}{
+		{
+			"param.user.id=alice",
+			QueryFilter{JSONFilters: []JSONPathFilter{{Source: "param", Path: []string{"user", "id"}, Value: "alice"}}},
+			[]string{"1"},
+		},
+		{
+			"response.isError=true (bool)",
+			QueryFilter{JSONFilters: []JSONPathFilter{{Source: "response", Path: []string{"isError"}, Value: "true"}}},
+			[]string{"2"},
+		},
+		{
+			"header.User-Agent=curl/8.0",
+			QueryFilter{JSONFilters: []JSONPathFilter{{Source: "header", Path: []string{"User-Agent"}, Value: "curl/8.0"}}},
+			[]string{"1"},
+		},
+		{
+			"has=response_error",
+			QueryFilter{HasKeys: []string{"response_error"}},
+			[]string{"2"},
+		},
+		{
+			"AND: param.user.id=alice AND has=request_headers",
+			QueryFilter{
+				JSONFilters: []JSONPathFilter{{Source: "param", Path: []string{"user", "id"}, Value: "alice"}},
+				HasKeys:     []string{"request_headers"},
+			},
+			[]string{"1"},
+		},
+	}
+	for _, c := range cases {
+		evs, err := m.Query(context.Background(), c.filter)
+		if err != nil {
+			t.Errorf("%s: %v", c.name, err)
+			continue
+		}
+		var got []string
+		for _, ev := range evs {
+			got = append(got, ev.ID)
+		}
+		if !equalStringSlice(got, c.ids) {
+			t.Errorf("%s: ids = %v, want %v", c.name, got, c.ids)
+		}
+	}
+}
+
+func TestMemoryLogger_Stream(t *testing.T) {
+	m := NewMemoryLogger()
+	now := time.Now().UTC()
+	for i := 0; i < 5; i++ {
+		_ = m.Log(context.Background(), Event{
+			ID:        string(rune('a' + i)),
+			ToolName:  "echo",
+			Timestamp: now.Add(time.Duration(i) * time.Second),
+			Success:   true,
+			Transport: "http",
+			Source:    "mcp",
+		})
+	}
+	var seen []string
+	if err := m.Stream(context.Background(), QueryFilter{}, func(ev Event) error {
+		seen = append(seen, ev.ID)
+		return nil
+	}); err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	// Stream returns Query order (DESC by ts), so newest first.
+	if len(seen) != 5 || seen[0] != "e" || seen[4] != "a" {
+		t.Errorf("seen = %v, want [e d c b a]", seen)
+	}
+}
+
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func TestMemoryLogger_TimeSeries(t *testing.T) {
 	m := NewMemoryLogger()
 	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)

--- a/pkg/audit/memory_test.go
+++ b/pkg/audit/memory_test.go
@@ -139,6 +139,65 @@ func TestMemoryLogger_JSONFiltersAndHasKeys(t *testing.T) {
 	}
 }
 
+func TestMemoryLogger_Query_TiedTimestampsAreStable(t *testing.T) {
+	// Tied timestamps must produce a deterministic Query order matching
+	// the Postgres backend (ts DESC, id ASC). Without the id tiebreaker
+	// the two backends could diverge under any ts collision and Stream
+	// pagination consumers would see flaky results.
+	m := NewMemoryLogger()
+	tied := time.Now().UTC()
+	for _, id := range []string{"c", "a", "b"} {
+		_ = m.Log(context.Background(), Event{
+			ID:        id,
+			ToolName:  "echo",
+			Timestamp: tied,
+			Success:   true,
+			Transport: "http",
+			Source:    "mcp",
+		})
+	}
+	got, _ := m.Query(context.Background(), QueryFilter{})
+	if len(got) != 3 {
+		t.Fatalf("len = %d", len(got))
+	}
+	want := []string{"a", "b", "c"}
+	for i, ev := range got {
+		if ev.ID != want[i] {
+			t.Errorf("got[%d] = %q, want %q (full: %v)", i, ev.ID,
+				want[i], []string{got[0].ID, got[1].ID, got[2].ID})
+		}
+	}
+}
+
+func TestMemoryLogger_Stream_IgnoresLimit(t *testing.T) {
+	// Per the StreamingLogger contract, f.Limit is ignored: Stream
+	// iterates the whole filtered set so callers can stop via a sentinel
+	// from fn. A regression that forwards Limit to Query would silently
+	// truncate exports.
+	m := NewMemoryLogger()
+	now := time.Now().UTC()
+	for i := 0; i < 5; i++ {
+		_ = m.Log(context.Background(), Event{
+			ID:        string(rune('a' + i)),
+			Timestamp: now.Add(time.Duration(i) * time.Second),
+			ToolName:  "echo",
+			Success:   true,
+			Transport: "http",
+			Source:    "mcp",
+		})
+	}
+	count := 0
+	if err := m.Stream(context.Background(), QueryFilter{Limit: 2}, func(Event) error {
+		count++
+		return nil
+	}); err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	if count != 5 {
+		t.Errorf("count = %d, want 5 (Limit must be ignored)", count)
+	}
+}
+
 func TestMemoryLogger_Stream(t *testing.T) {
 	m := NewMemoryLogger()
 	now := time.Now().UTC()

--- a/pkg/audit/memory_test.go
+++ b/pkg/audit/memory_test.go
@@ -169,6 +169,69 @@ func TestMemoryLogger_Query_TiedTimestampsAreStable(t *testing.T) {
 	}
 }
 
+func TestMemoryLogger_Query_ClampsAboveMaxQueryLimit(t *testing.T) {
+	// Backend-consistency: MemoryLogger and Postgres must agree on
+	// the upper-bound clamp. Without this clamp, test code that uses
+	// MemoryLogger as a stand-in for Postgres masks production
+	// behavior. Push more than MaxQueryLimit, ask for more; assert
+	// the cap holds.
+	m := NewMemoryLogger()
+	for i := 0; i < MaxQueryLimit+50; i++ {
+		_ = m.Log(context.Background(), Event{
+			ID:        string(rune('a' + (i % 26))),
+			ToolName:  "echo",
+			Timestamp: time.Now().UTC().Add(time.Duration(i) * time.Microsecond),
+			Success:   true,
+			Transport: "http",
+			Source:    "mcp",
+		})
+	}
+	got, _ := m.Query(context.Background(), QueryFilter{Limit: MaxQueryLimit + 9999})
+	if len(got) != MaxQueryLimit {
+		t.Errorf("got %d events with Limit=MaxQueryLimit+9999, want %d (clamp must enforce upper bound)",
+			len(got), MaxQueryLimit)
+	}
+}
+
+func TestMemoryLogger_CountAndStream_NotCappedAtQueryDefault(t *testing.T) {
+	// Regression: an earlier fix made Query default Limit=0 to 100. If
+	// Count or Stream route through Query (instead of using matchAll
+	// directly), they silently truncate at 100. Write more than 100
+	// events and verify both methods see all of them.
+	m := NewMemoryLogger()
+	const n = 250
+	now := time.Now().UTC()
+	for i := 0; i < n; i++ {
+		_ = m.Log(context.Background(), Event{
+			ID:        string(rune('a' + (i % 26))),
+			ToolName:  "echo",
+			Timestamp: now.Add(time.Duration(i) * time.Microsecond),
+			Success:   true,
+			Transport: "http",
+			Source:    "mcp",
+		})
+	}
+
+	got, err := m.Count(context.Background(), QueryFilter{})
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+	if got != n {
+		t.Errorf("Count = %d, want %d (must not be capped at Query default)", got, n)
+	}
+
+	streamSeen := 0
+	if err := m.Stream(context.Background(), QueryFilter{}, func(Event) error {
+		streamSeen++
+		return nil
+	}); err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	if streamSeen != n {
+		t.Errorf("Stream visited %d events, want %d (must not be capped at Query default)", streamSeen, n)
+	}
+}
+
 func TestMemoryLogger_Stream_IgnoresLimit(t *testing.T) {
 	// Per the StreamingLogger contract, f.Limit is ignored: Stream
 	// iterates the whole filtered set so callers can stop via a sentinel

--- a/pkg/audit/postgres/store.go
+++ b/pkg/audit/postgres/store.go
@@ -284,18 +284,28 @@ func (s *Store) Query(ctx context.Context, f audit.QueryFilter) ([]audit.Event, 
 // in memory for export endpoints; pgx itself uses a network-level
 // cursor under the hood.
 //
-// Stream forces f.Limit to the largest value buildSelect accepts (1000)
-// and walks pages with f.Offset until the underlying query returns no
-// rows. That keeps each round trip bounded while still allowing
-// arbitrarily large filtered exports.
+// Stream uses MaxQueryLimit as the page size and walks pages with
+// f.Offset until a page returns fewer rows. Sharing one constant with
+// buildSelect avoids a silent reset to the much smaller default if
+// either side moves.
+//
+// Concurrent-insert caveat: ORDER BY ts DESC + OFFSET pagination is
+// unstable when new rows arrive at the head between pages, since each
+// new row shifts every later row down by one offset slot. Under heavy
+// concurrent writes during a long export, a row at the page boundary
+// can appear in two consecutive pages. Consumers that care should
+// dedupe by Event.ID; a future revision can switch to a ts cursor
+// (WHERE ts < $cursor) for a true snapshot guarantee.
 func (s *Store) Stream(ctx context.Context, f audit.QueryFilter, fn func(audit.Event) error) error {
-	const pageSize = 1000
 	page := f
-	page.Limit = pageSize
+	page.Limit = MaxQueryLimit
 	if page.Offset < 0 {
 		page.Offset = 0
 	}
 	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		q, args := buildSelect(page, false)
 		rows, err := s.pool.Query(ctx, q, args...)
 		if err != nil {
@@ -319,10 +329,10 @@ func (s *Store) Stream(ctx context.Context, f audit.QueryFilter, fn func(audit.E
 			return err
 		}
 		rows.Close()
-		if count < pageSize {
+		if count < MaxQueryLimit {
 			return nil
 		}
-		page.Offset += pageSize
+		page.Offset += MaxQueryLimit
 	}
 }
 
@@ -485,6 +495,13 @@ func breakdownColumn(dim string) string {
 	return ""
 }
 
+// MaxQueryLimit is the largest LIMIT buildSelect will honor. Shared
+// with Stream so the two stay in sync; a value bigger than this gets
+// silently reset by buildSelect, which would otherwise make Stream
+// take 10x more roundtrips. Keep them coupled by always referencing
+// this constant.
+const MaxQueryLimit = 1000
+
 // jsonFilterColumn maps a QueryFilter.JSONPathFilter Source into the
 // audit_payloads JSONB column name. Unknown sources return "" and are
 // skipped at the call site.
@@ -558,13 +575,16 @@ func buildSelect(f audit.QueryFilter, count bool) (string, []any) {
 		}
 		var doc any
 		if jf.Source == "header" {
-			// Headers are stored as {"User-Agent":["curl/8.0"]} so the
-			// containment doc must be wrapped in an array at the leaf.
+			// Headers are stored as {"User-Agent":["curl/8.0"]}: the
+			// containment doc wraps the value in an array at the leaf.
+			// Header values are always strings on the wire; force the
+			// raw value rather than running it through ParseJSONFilterValue
+			// so ?header.X-Count=42 matches a stored "42" not JSON 42.
 			if len(jf.Path) == 0 {
 				continue
 			}
 			doc = map[string]any{
-				jf.Path[0]: []any{audit.ParseJSONFilterValue(jf.Value)},
+				jf.Path[0]: []any{jf.Value},
 			}
 		} else {
 			doc = audit.JSONFilterToContainment(jf.Path, audit.ParseJSONFilterValue(jf.Value))
@@ -604,7 +624,7 @@ func buildSelect(f audit.QueryFilter, count bool) (string, []any) {
 	}
 
 	limit := f.Limit
-	if limit <= 0 || limit > 1000 {
+	if limit <= 0 || limit > MaxQueryLimit {
 		limit = 100
 	}
 	args = append(args, limit, f.Offset)

--- a/pkg/audit/postgres/store.go
+++ b/pkg/audit/postgres/store.go
@@ -496,6 +496,16 @@ func breakdownColumn(dim string) string {
 	return ""
 }
 
+// truncateForLog returns s capped at max bytes, with an ellipsis
+// suffix when truncated. Used by the JSON-filter compile-error log so
+// a malformed path doesn't blow out the slog line.
+func truncateForLog(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}
+
 // jsonFilterColumn maps a QueryFilter.JSONPathFilter Source into the
 // audit_payloads JSONB column name. Unknown sources return "" and are
 // skipped at the call site.
@@ -585,6 +595,18 @@ func buildSelect(f audit.QueryFilter, count bool) (string, []any) {
 		}
 		b, err := json.Marshal(doc)
 		if err != nil {
+			// Silently dropping the filter would broaden the result
+			// set without telling the operator. Log and skip; the
+			// filter inputs are constructed from sanitized URL parts
+			// plus ParseJSONFilterValue output, so this branch should
+			// be unreachable in practice. We log the joined path
+			// (capped) so an operator can correlate against the
+			// failing request.
+			slog.Warn("audit: json filter compile failed; filter dropped",
+				"source", jf.Source,
+				"path", truncateForLog(strings.Join(jf.Path, "."), 256),
+				"err", err,
+			)
 			continue
 		}
 		conds = append(conds, fmt.Sprintf(
@@ -595,16 +617,33 @@ func buildSelect(f audit.QueryFilter, count bool) (string, []any) {
 		i++
 	}
 
-	// has= filters: shorthand for "this payload column is populated".
-	// Validated against AllowedHasKeys at the HTTP layer; safe to splice
-	// the column name verbatim into SQL since it's not user input.
+	// has= filters: shorthand for "this payload column is non-empty".
+	// We treat NULL, empty-JSONB forms ('{}'::jsonb, '[]'::jsonb,
+	// 'null'::jsonb), and empty TEXT ('') as "missing"; only a payload
+	// column with actual content counts. This matches MemoryLogger's
+	// len/IsZero-based check on every allowlisted column type
+	// (request_* / response_* / notifications are JSONB; replayed_from
+	// is TEXT) so the two backends agree on edge cases.
+	//
+	// The empty-string entry covers the TEXT column case (replayed_from)
+	// where '' is a valid stored value but semantically "missing." For
+	// JSONB columns, '' isn't a valid stored value so the entry is a
+	// harmless extra match.
+	//
+	// Validated against AllowedHasKeys at the HTTP layer; the column
+	// name is allow-listed so the verbatim splice is safe. Note: this
+	// loop deliberately does NOT increment `i`; no $N placeholder is
+	// bound here. A future maintainer adding a bound argument must
+	// increment `i` to keep LIMIT/OFFSET aligned.
 	for _, k := range f.HasKeys {
 		if !audit.IsAllowedHasKey(k) {
 			continue
 		}
 		conds = append(conds, fmt.Sprintf(
-			"EXISTS (SELECT 1 FROM audit_payloads p WHERE p.event_id = audit_events.id AND p.%s IS NOT NULL)",
-			k,
+			"EXISTS (SELECT 1 FROM audit_payloads p WHERE p.event_id = audit_events.id "+
+				"AND p.%s IS NOT NULL "+
+				"AND p.%s::text NOT IN ('{}', '[]', 'null', ''))",
+			k, k,
 		))
 	}
 
@@ -617,9 +656,16 @@ func buildSelect(f audit.QueryFilter, count bool) (string, []any) {
 		return "SELECT count(*) FROM audit_events" + where, args
 	}
 
+	// Two distinct cases, kept separate so the doc on audit.MaxQueryLimit
+	// ("larger values get silently reduced") is honored. A caller asking
+	// for too much is clamped to MaxQueryLimit, not collapsed back to the
+	// page-size default; an unset limit gets the page-size default.
 	limit := f.Limit
-	if limit <= 0 || limit > audit.MaxQueryLimit {
+	if limit <= 0 {
 		limit = 100
+	}
+	if limit > audit.MaxQueryLimit {
+		limit = audit.MaxQueryLimit
 	}
 	args = append(args, limit, f.Offset)
 	return "SELECT id, ts, duration_ms, " +

--- a/pkg/audit/postgres/store.go
+++ b/pkg/audit/postgres/store.go
@@ -279,6 +279,53 @@ func (s *Store) Query(ctx context.Context, f audit.QueryFilter) ([]audit.Event, 
 	return out, rows.Err()
 }
 
+// Stream iterates the filtered event set via the same SELECT used by
+// Query, calling fn once per row. This avoids buffering the full set
+// in memory for export endpoints; pgx itself uses a network-level
+// cursor under the hood.
+//
+// Stream forces f.Limit to the largest value buildSelect accepts (1000)
+// and walks pages with f.Offset until the underlying query returns no
+// rows. That keeps each round trip bounded while still allowing
+// arbitrarily large filtered exports.
+func (s *Store) Stream(ctx context.Context, f audit.QueryFilter, fn func(audit.Event) error) error {
+	const pageSize = 1000
+	page := f
+	page.Limit = pageSize
+	if page.Offset < 0 {
+		page.Offset = 0
+	}
+	for {
+		q, args := buildSelect(page, false)
+		rows, err := s.pool.Query(ctx, q, args...)
+		if err != nil {
+			return err
+		}
+		count := 0
+		for rows.Next() {
+			ev, err := scanEvent(rows)
+			if err != nil {
+				rows.Close()
+				return err
+			}
+			if err := fn(ev); err != nil {
+				rows.Close()
+				return err
+			}
+			count++
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return err
+		}
+		rows.Close()
+		if count < pageSize {
+			return nil
+		}
+		page.Offset += pageSize
+	}
+}
+
 // Count returns the number of matching events without paging.
 func (s *Store) Count(ctx context.Context, f audit.QueryFilter) (int64, error) {
 	q, args := buildSelect(f, true)
@@ -438,6 +485,21 @@ func breakdownColumn(dim string) string {
 	return ""
 }
 
+// jsonFilterColumn maps a QueryFilter.JSONPathFilter Source into the
+// audit_payloads JSONB column name. Unknown sources return "" and are
+// skipped at the call site.
+func jsonFilterColumn(source string) string {
+	switch source {
+	case "param":
+		return "request_params"
+	case "response":
+		return "response_result"
+	case "header":
+		return "request_headers"
+	}
+	return ""
+}
+
 func buildSelect(f audit.QueryFilter, count bool) (string, []any) {
 	var (
 		conds []string
@@ -481,6 +543,55 @@ func buildSelect(f audit.QueryFilter, count bool) (string, []any) {
 		like := "%" + escapeLike(f.Search) + "%"
 		args = append(args, like, like, like)
 		i += 3
+	}
+
+	// JSON path filters: each compiles to an EXISTS subquery against
+	// audit_payloads.<column> @> $N::jsonb. The containment doc is built
+	// from the dotted path so a single ?param.user.id=alice produces
+	// {"user":{"id":"alice"}}, which the GIN(jsonb_path_ops) index can
+	// answer cheaply. Source has already been validated against the
+	// closed AllowedJSONSources set at the HTTP layer.
+	for _, jf := range f.JSONFilters {
+		col := jsonFilterColumn(jf.Source)
+		if col == "" {
+			continue
+		}
+		var doc any
+		if jf.Source == "header" {
+			// Headers are stored as {"User-Agent":["curl/8.0"]} so the
+			// containment doc must be wrapped in an array at the leaf.
+			if len(jf.Path) == 0 {
+				continue
+			}
+			doc = map[string]any{
+				jf.Path[0]: []any{audit.ParseJSONFilterValue(jf.Value)},
+			}
+		} else {
+			doc = audit.JSONFilterToContainment(jf.Path, audit.ParseJSONFilterValue(jf.Value))
+		}
+		b, err := json.Marshal(doc)
+		if err != nil {
+			continue
+		}
+		conds = append(conds, fmt.Sprintf(
+			"EXISTS (SELECT 1 FROM audit_payloads p WHERE p.event_id = audit_events.id AND p.%s @> $%d::jsonb)",
+			col, i,
+		))
+		args = append(args, string(b))
+		i++
+	}
+
+	// has= filters: shorthand for "this payload column is populated".
+	// Validated against AllowedHasKeys at the HTTP layer; safe to splice
+	// the column name verbatim into SQL since it's not user input.
+	for _, k := range f.HasKeys {
+		if !audit.IsAllowedHasKey(k) {
+			continue
+		}
+		conds = append(conds, fmt.Sprintf(
+			"EXISTS (SELECT 1 FROM audit_payloads p WHERE p.event_id = audit_events.id AND p.%s IS NOT NULL)",
+			k,
+		))
 	}
 
 	where := ""

--- a/pkg/audit/postgres/store.go
+++ b/pkg/audit/postgres/store.go
@@ -284,7 +284,7 @@ func (s *Store) Query(ctx context.Context, f audit.QueryFilter) ([]audit.Event, 
 // in memory for export endpoints; pgx itself uses a network-level
 // cursor under the hood.
 //
-// Stream uses MaxQueryLimit as the page size and walks pages with
+// Stream uses audit.MaxQueryLimit as the page size and walks pages with
 // f.Offset until a page returns fewer rows. Sharing one constant with
 // buildSelect avoids a silent reset to the much smaller default if
 // either side moves.
@@ -297,11 +297,12 @@ func (s *Store) Query(ctx context.Context, f audit.QueryFilter) ([]audit.Event, 
 // dedupe by Event.ID; a future revision can switch to a ts cursor
 // (WHERE ts < $cursor) for a true snapshot guarantee.
 func (s *Store) Stream(ctx context.Context, f audit.QueryFilter, fn func(audit.Event) error) error {
+	// Per the StreamingLogger contract f.Limit and f.Offset are
+	// ignored; Stream iterates the whole filtered set and uses an
+	// internal page cursor (page.Offset) for pagination.
 	page := f
-	page.Limit = MaxQueryLimit
-	if page.Offset < 0 {
-		page.Offset = 0
-	}
+	page.Limit = audit.MaxQueryLimit
+	page.Offset = 0
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -329,10 +330,10 @@ func (s *Store) Stream(ctx context.Context, f audit.QueryFilter, fn func(audit.E
 			return err
 		}
 		rows.Close()
-		if count < MaxQueryLimit {
+		if count < audit.MaxQueryLimit {
 			return nil
 		}
-		page.Offset += MaxQueryLimit
+		page.Offset += audit.MaxQueryLimit
 	}
 }
 
@@ -495,13 +496,6 @@ func breakdownColumn(dim string) string {
 	return ""
 }
 
-// MaxQueryLimit is the largest LIMIT buildSelect will honor. Shared
-// with Stream so the two stay in sync; a value bigger than this gets
-// silently reset by buildSelect, which would otherwise make Stream
-// take 10x more roundtrips. Keep them coupled by always referencing
-// this constant.
-const MaxQueryLimit = 1000
-
 // jsonFilterColumn maps a QueryFilter.JSONPathFilter Source into the
 // audit_payloads JSONB column name. Unknown sources return "" and are
 // skipped at the call site.
@@ -624,7 +618,7 @@ func buildSelect(f audit.QueryFilter, count bool) (string, []any) {
 	}
 
 	limit := f.Limit
-	if limit <= 0 || limit > MaxQueryLimit {
+	if limit <= 0 || limit > audit.MaxQueryLimit {
 		limit = 100
 	}
 	args = append(args, limit, f.Offset)
@@ -637,7 +631,12 @@ func buildSelect(f audit.QueryFilter, count bool) (string, []any) {
 		"request_chars, response_chars, content_blocks, " +
 		"transport, source, COALESCE(remote_addr, ''), COALESCE(user_agent, '') " +
 		"FROM audit_events" + where +
-		" ORDER BY ts DESC" +
+		// id ASC is the tiebreaker for tied timestamps. Without it,
+		// two events with the same ts can swap positions between pages
+		// of a Stream walk, causing both duplicate emission and missed
+		// emission across page boundaries. Tied ts is common under any
+		// sub-millisecond write rate.
+		" ORDER BY ts DESC, id ASC" +
 		fmt.Sprintf(" LIMIT $%d OFFSET $%d", i, i+1), args
 }
 

--- a/pkg/audit/postgres/store_test.go
+++ b/pkg/audit/postgres/store_test.go
@@ -285,6 +285,57 @@ func TestStore_JSONFilters_AndHasKeys(t *testing.T) {
 	}
 }
 
+func TestStore_Stream_TiedTimestampsNoDuplicatesOrSkips(t *testing.T) {
+	// Tied timestamps + OFFSET pagination is the worst case: without an
+	// id tiebreaker on ORDER BY, the same row can appear in two
+	// consecutive pages and a different row can be skipped entirely.
+	// Write 1100 events all sharing one ts, then assert Stream visits
+	// each id exactly once.
+	ctx := context.Background()
+	url := startPostgres(ctx, t)
+	if err := migrate.Up(url); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := pgxpool.New(ctx, url)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	store := auditpg.New(pool)
+
+	const n = 1100
+	tied := time.Now().UTC().Truncate(time.Second)
+	for i := 0; i < n; i++ {
+		ev := audit.Event{
+			ID:        fmt.Sprintf("evt-%04d", i),
+			Timestamp: tied,
+			ToolName:  "echo",
+			Transport: "http",
+			Source:    "mcp",
+			Success:   true,
+		}
+		if err := store.Log(ctx, ev); err != nil {
+			t.Fatalf("Log %d: %v", i, err)
+		}
+	}
+
+	seen := make(map[string]int, n)
+	if err := store.Stream(ctx, audit.QueryFilter{}, func(ev audit.Event) error {
+		seen[ev.ID]++
+		return nil
+	}); err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	if len(seen) != n {
+		t.Fatalf("distinct ids visited = %d, want %d", len(seen), n)
+	}
+	for id, c := range seen {
+		if c != 1 {
+			t.Errorf("id %s seen %d times, want 1 (duplicate at page boundary)", id, c)
+		}
+	}
+}
+
 func TestStore_Stream_PagesThroughCursor(t *testing.T) {
 	ctx := context.Background()
 	url := startPostgres(ctx, t)

--- a/pkg/audit/postgres/store_test.go
+++ b/pkg/audit/postgres/store_test.go
@@ -12,6 +12,7 @@ package auditpg_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -168,6 +169,185 @@ func TestStore_Log_NilPayloadOnlyWritesSummary(t *testing.T) {
 	if n != 1 {
 		t.Errorf("summary row count = %d, want 1", n)
 	}
+}
+
+func TestStore_JSONFilters_AndHasKeys(t *testing.T) {
+	// End-to-end: write events with diverse payloads, then assert the
+	// JSONB filter compiler matches the same events the MemoryLogger
+	// would. Hits the real GIN(jsonb_path_ops) index path.
+	ctx := context.Background()
+	url := startPostgres(ctx, t)
+	if err := migrate.Up(url); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := pgxpool.New(ctx, url)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	store := auditpg.New(pool)
+
+	now := time.Now().UTC()
+	mustLog := func(id string, p *audit.Payload, success bool) {
+		t.Helper()
+		ev := audit.Event{
+			ID:        id,
+			Timestamp: now,
+			ToolName:  "echo",
+			Transport: "http",
+			Source:    "mcp",
+			Success:   success,
+			Payload:   p,
+		}
+		if err := store.Log(ctx, ev); err != nil {
+			t.Fatalf("Log %s: %v", id, err)
+		}
+	}
+	mustLog("alice", &audit.Payload{
+		JSONRPCMethod:  "tools/call",
+		RequestParams:  map[string]any{"message": "hello", "user": map[string]any{"id": "alice"}},
+		ResponseResult: map[string]any{"isError": false, "content": []any{map[string]any{"type": "text", "text": "hi"}}},
+		RequestHeaders: map[string][]string{"User-Agent": {"curl/8.0"}},
+	}, true)
+	mustLog("bob", &audit.Payload{
+		JSONRPCMethod:  "tools/call",
+		RequestParams:  map[string]any{"message": "world", "user": map[string]any{"id": "bob"}},
+		ResponseResult: map[string]any{"isError": true},
+		ResponseError:  map[string]any{"category": "tool", "message": "boom"},
+	}, false)
+	mustLog("carol-no-payload", nil, true)
+
+	cases := []struct {
+		name   string
+		filter audit.QueryFilter
+		ids    []string
+	}{
+		{
+			"param.user.id=alice",
+			audit.QueryFilter{JSONFilters: []audit.JSONPathFilter{
+				{Source: "param", Path: []string{"user", "id"}, Value: "alice"},
+			}},
+			[]string{"alice"},
+		},
+		{
+			"response.isError=true",
+			audit.QueryFilter{JSONFilters: []audit.JSONPathFilter{
+				{Source: "response", Path: []string{"isError"}, Value: "true"},
+			}},
+			[]string{"bob"},
+		},
+		{
+			"header.User-Agent=curl/8.0",
+			audit.QueryFilter{JSONFilters: []audit.JSONPathFilter{
+				{Source: "header", Path: []string{"User-Agent"}, Value: "curl/8.0"},
+			}},
+			[]string{"alice"},
+		},
+		{
+			"has=response_error",
+			audit.QueryFilter{HasKeys: []string{"response_error"}},
+			[]string{"bob"},
+		},
+		{
+			"has=request_headers",
+			audit.QueryFilter{HasKeys: []string{"request_headers"}},
+			[]string{"alice"},
+		},
+		{
+			"AND: param.user.id=alice + has=request_headers",
+			audit.QueryFilter{
+				JSONFilters: []audit.JSONPathFilter{{Source: "param", Path: []string{"user", "id"}, Value: "alice"}},
+				HasKeys:     []string{"request_headers"},
+			},
+			[]string{"alice"},
+		},
+		{
+			"no-match path",
+			audit.QueryFilter{JSONFilters: []audit.JSONPathFilter{
+				{Source: "param", Path: []string{"user", "id"}, Value: "nobody"},
+			}},
+			nil,
+		},
+	}
+	for _, c := range cases {
+		evs, err := store.Query(ctx, c.filter)
+		if err != nil {
+			t.Errorf("%s: Query err: %v", c.name, err)
+			continue
+		}
+		var ids []string
+		for _, ev := range evs {
+			ids = append(ids, ev.ID)
+		}
+		if !equalStringsAny(ids, c.ids) {
+			t.Errorf("%s: ids = %v, want %v", c.name, ids, c.ids)
+		}
+	}
+}
+
+func TestStore_Stream_PagesThroughCursor(t *testing.T) {
+	ctx := context.Background()
+	url := startPostgres(ctx, t)
+	if err := migrate.Up(url); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := pgxpool.New(ctx, url)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	store := auditpg.New(pool)
+
+	// Write enough events to span multiple internal pages. The Stream
+	// implementation pages at 1000 rows; we go just past that to prove
+	// the page-loop pagination works end-to-end.
+	const n = 1100
+	now := time.Now().UTC()
+	for i := 0; i < n; i++ {
+		ev := audit.Event{
+			ID:        fmt.Sprintf("evt-%04d", i),
+			Timestamp: now.Add(time.Duration(i) * time.Millisecond),
+			ToolName:  "echo",
+			Transport: "http",
+			Source:    "mcp",
+			Success:   true,
+		}
+		if err := store.Log(ctx, ev); err != nil {
+			t.Fatalf("Log: %v", err)
+		}
+	}
+
+	seen := 0
+	if err := store.Stream(ctx, audit.QueryFilter{}, func(audit.Event) error {
+		seen++
+		return nil
+	}); err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	if seen != n {
+		t.Errorf("Stream visited %d events, want %d", seen, n)
+	}
+}
+
+func equalStringsAny(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	// Postgres ORDER BY ts DESC + same ts: ordering inside a tie is
+	// undefined. Compare as sets for these small fixtures.
+	am := map[string]int{}
+	for _, s := range a {
+		am[s]++
+	}
+	for _, s := range b {
+		am[s]--
+	}
+	for _, v := range am {
+		if v != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func TestStore_GetPayload_NotFound(t *testing.T) {

--- a/pkg/audit/postgres/store_test.go
+++ b/pkg/audit/postgres/store_test.go
@@ -285,6 +285,63 @@ func TestStore_JSONFilters_AndHasKeys(t *testing.T) {
 	}
 }
 
+func TestStore_Query_LimitClamping(t *testing.T) {
+	// buildSelect has two branches for Limit:
+	//   - Limit <= 0: default to 100
+	//   - Limit > MaxQueryLimit: clamp to MaxQueryLimit
+	// Verify both, plus a passing-through case in the middle, against
+	// real Postgres so a regression that collapses the branches surfaces.
+	ctx := context.Background()
+	url := startPostgres(ctx, t)
+	if err := migrate.Up(url); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := pgxpool.New(ctx, url)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	store := auditpg.New(pool)
+
+	// Need MaxQueryLimit + 50 events to exercise the clamp.
+	const stored = audit.MaxQueryLimit + 50
+	now := time.Now().UTC()
+	for i := 0; i < stored; i++ {
+		ev := audit.Event{
+			ID:        fmt.Sprintf("evt-%05d", i),
+			Timestamp: now.Add(time.Duration(i) * time.Millisecond),
+			ToolName:  "echo",
+			Transport: "http",
+			Source:    "mcp",
+			Success:   true,
+		}
+		if err := store.Log(ctx, ev); err != nil {
+			t.Fatalf("Log: %v", err)
+		}
+	}
+
+	cases := []struct {
+		name  string
+		limit int
+		want  int
+	}{
+		{"unset (Limit=0) defaults to 100", 0, 100},
+		{"explicit small Limit honored", 25, 25},
+		{"Limit at MaxQueryLimit honored", audit.MaxQueryLimit, audit.MaxQueryLimit},
+		{"Limit above MaxQueryLimit clamped", audit.MaxQueryLimit + 9999, audit.MaxQueryLimit},
+	}
+	for _, c := range cases {
+		got, err := store.Query(ctx, audit.QueryFilter{Limit: c.limit})
+		if err != nil {
+			t.Errorf("%s: %v", c.name, err)
+			continue
+		}
+		if len(got) != c.want {
+			t.Errorf("%s: got %d, want %d", c.name, len(got), c.want)
+		}
+	}
+}
+
 func TestStore_Stream_TiedTimestampsNoDuplicatesOrSkips(t *testing.T) {
 	// Tied timestamps + OFFSET pagination is the worst case: without an
 	// id tiebreaker on ORDER BY, the same row can appear in two
@@ -377,6 +434,21 @@ func TestStore_Stream_PagesThroughCursor(t *testing.T) {
 	}
 	if seen != n {
 		t.Errorf("Stream visited %d events, want %d", seen, n)
+	}
+
+	// Per StreamingLogger contract, f.Offset is ignored: Stream walks
+	// the whole filtered set even if the caller passes a non-zero
+	// Offset. Without this assertion, a regression that drops the
+	// page.Offset = 0 line would silently truncate exports.
+	seenWithOffset := 0
+	if err := store.Stream(ctx, audit.QueryFilter{Offset: 500}, func(audit.Event) error {
+		seenWithOffset++
+		return nil
+	}); err != nil {
+		t.Fatalf("Stream with Offset=500: %v", err)
+	}
+	if seenWithOffset != n {
+		t.Errorf("Stream with Offset=500 visited %d, want %d (Offset must be ignored)", seenWithOffset, n)
 	}
 }
 

--- a/pkg/httpsrv/portal_api.go
+++ b/pkg/httpsrv/portal_api.go
@@ -119,6 +119,21 @@ func (p *PortalAPI) toolDetail(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
 }
 
+// validPath reports whether path is non-empty and has no empty segments.
+// "?param.a..b=v" parses to ["a","","b"] which can't match any real
+// payload; rather than silently building a doomed filter, drop it.
+func validPath(path []string) bool {
+	if len(path) == 0 {
+		return false
+	}
+	for _, seg := range path {
+		if seg == "" {
+			return false
+		}
+	}
+	return true
+}
+
 func parseQueryFilter(r *http.Request) audit.QueryFilter {
 	q := r.URL.Query()
 	f := audit.QueryFilter{}
@@ -151,9 +166,9 @@ func parseQueryFilter(r *http.Request) audit.QueryFilter {
 	}
 
 	// JSONB path filters and has= shortcuts. Anything malformed
-	// (unknown source, empty path, unknown has key) is silently dropped
-	// rather than failing the whole query, matching how unknown plain
-	// query params are handled above.
+	// (unknown source, empty path segment, unknown has key) is silently
+	// dropped rather than failing the whole query, matching how unknown
+	// plain query params are handled above.
 	for k, vs := range q {
 		switch {
 		case strings.HasPrefix(k, "param."), strings.HasPrefix(k, "response."), strings.HasPrefix(k, "header."):
@@ -162,8 +177,15 @@ func parseQueryFilter(r *http.Request) audit.QueryFilter {
 				continue
 			}
 			path := audit.SplitJSONPath(rest)
-			if len(path) == 0 {
+			if !validPath(path) {
 				continue
+			}
+			// Headers are stored under the canonical Go form
+			// (User-Agent, X-Api-Key, etc.). Operators commonly write
+			// them in lower-case in URLs and config; canonicalize so
+			// ?header.user-agent matches ?header.User-Agent.
+			if source == "header" {
+				path[0] = http.CanonicalHeaderKey(path[0])
 			}
 			for _, v := range vs {
 				if v == "" {
@@ -312,6 +334,11 @@ func (p *PortalAPI) auditExport(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 
 	enc := json.NewEncoder(w)
+	// NDJSON consumers want bytes-as-written; default HTML escaping turns
+	// "<" into "<" inside captured tool output, which surprises
+	// operators eyeballing the file. Tools downstream parse either form
+	// fine, but readability matters here.
+	enc.SetEscapeHTML(false)
 	written := 0
 	flusher, _ := w.(http.Flusher)
 	err := sl.Stream(r.Context(), f, func(ev audit.Event) error {

--- a/pkg/httpsrv/portal_api.go
+++ b/pkg/httpsrv/portal_api.go
@@ -1,6 +1,7 @@
 package httpsrv
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -119,9 +120,13 @@ func (p *PortalAPI) toolDetail(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
 }
 
-// validPath reports whether path is non-empty and has no empty segments.
-// "?param.a..b=v" parses to ["a","","b"] which can't match any real
-// payload; rather than silently building a doomed filter, drop it.
+// validPath reports whether path is non-empty, has no empty segments,
+// and contains no ASCII control characters. Empty segments
+// ("?param.a..b=v" -> ["a","","b"]) can't match any real payload, and
+// control bytes in a path could land in slog lines (a malformed-filter
+// path is logged via truncateForLog) and inject newlines / tabs into
+// the log stream. Reject at parse time rather than depending on every
+// downstream sink to sanitize.
 func validPath(path []string) bool {
 	if len(path) == 0 {
 		return false
@@ -129,6 +134,12 @@ func validPath(path []string) bool {
 	for _, seg := range path {
 		if seg == "" {
 			return false
+		}
+		for i := 0; i < len(seg); i++ {
+			c := seg[i]
+			if c < 0x20 || c == 0x7f {
+				return false
+			}
 		}
 	}
 	return true
@@ -180,11 +191,15 @@ func parseQueryFilter(r *http.Request) audit.QueryFilter {
 			if !validPath(path) {
 				continue
 			}
-			// Headers are stored under the canonical Go form
-			// (User-Agent, X-Api-Key, etc.). Operators commonly write
-			// them in lower-case in URLs and config; canonicalize so
-			// ?header.user-agent matches ?header.User-Agent.
+			// Headers are a flat map[string][]string on the wire and on
+			// disk; only one path segment is meaningful (the header name).
+			// Reject ?header.X-Api-Key.foo=v at parse time rather than
+			// silently truncating .foo, which would mislead the operator
+			// about what was actually matched.
 			if source == "header" {
+				if len(path) != 1 {
+					continue
+				}
 				path[0] = http.CanonicalHeaderKey(path[0])
 			}
 			for _, v := range vs {
@@ -327,21 +342,38 @@ func (p *PortalAPI) auditExport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/x-ndjson")
-	// Suggest a filename for browser-driven downloads; consumers
-	// piping with curl/jq ignore Content-Disposition.
-	w.Header().Set("Content-Disposition", `attachment; filename="audit.jsonl"`)
-	w.WriteHeader(http.StatusOK)
-
+	// All response headers are deferred until the first row encodes
+	// successfully (or the no-rows-success terminal write). If Stream
+	// errors before any row (DB down, planner failure on first page),
+	// writeError can still send a real 5xx with the right Content-Type;
+	// if we'd already sent the ndjson + attachment headers, a 500 JSON
+	// body would download as "audit.jsonl" in a browser.
 	enc := json.NewEncoder(w)
-	// NDJSON consumers want bytes-as-written; default HTML escaping turns
-	// "<" into "<" inside captured tool output, which surprises
-	// operators eyeballing the file. Tools downstream parse either form
-	// fine, but readability matters here.
-	enc.SetEscapeHTML(false)
+	enc.SetEscapeHTML(false) // raw '<' in tool output, not "&lt;"
 	written := 0
+	headerWritten := false
 	flusher, _ := w.(http.Flusher)
+
+	// writeExportHeaders is the single place export-specific response
+	// headers are committed. Called once, atomically, before the first
+	// body byte. Audit data is operator-sensitive (user IDs, request
+	// payloads, error messages), so no-store is mandatory; the
+	// attachment hint is for browser-driven downloads.
+	writeExportHeaders := func() {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.Header().Set("Content-Disposition", `attachment; filename="audit.jsonl"`)
+		w.Header().Set("Cache-Control", "no-store")
+		w.WriteHeader(http.StatusOK)
+		headerWritten = true
+	}
+
 	err := sl.Stream(r.Context(), f, func(ev audit.Event) error {
+		// Per-row ctx check so a client disconnect doesn't waste a
+		// full Postgres page (1000 rows) before the page-level ctx
+		// check fires inside Stream itself.
+		if err := r.Context().Err(); err != nil {
+			return err
+		}
 		if written >= exportCap {
 			// Bail by returning a sentinel; the closure can't write a
 			// trailer mid-stream once headers are out, so just stop.
@@ -350,6 +382,9 @@ func (p *PortalAPI) auditExport(w http.ResponseWriter, r *http.Request) {
 		// Payload is summary-only on this endpoint; clear any in-memory
 		// pointer set by the underlying logger before encoding.
 		ev.Payload = nil
+		if !headerWritten {
+			writeExportHeaders()
+		}
 		if err := enc.Encode(&ev); err != nil {
 			return err
 		}
@@ -361,16 +396,44 @@ func (p *PortalAPI) auditExport(w http.ResponseWriter, r *http.Request) {
 		}
 		return nil
 	})
-	if err != nil && !errors.Is(err, errExportCapped) {
-		// Headers are already out, so we can only log + truncate the
-		// stream. The client will see a partial response.
+	switch {
+	case err == nil, errors.Is(err, errExportCapped):
+		// Success path. Filter that matched zero rows still owes the
+		// client 200 OK with an empty body.
+		if !headerWritten {
+			writeExportHeaders()
+		}
+		if flusher != nil {
+			flusher.Flush()
+		}
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		// Client disconnect or request timeout. If headers haven't
+		// gone out we deliberately do NOT commit them (avoids
+		// implicit 200 OK when the client gave up); if they have,
+		// flush the partial response so the client sees what we got.
+		if headerWritten && flusher != nil {
+			flusher.Flush()
+		}
+	case !headerWritten:
+		// Real backend error before the first row. Headers haven't
+		// committed yet, so we can return a usable status. We log
+		// the wrapped error at WARN and return a generic message to
+		// the client to avoid leaking pgx / driver internals.
+		slog.Warn("audit: export stream failed before first row",
+			"err", err,
+		)
+		writeError(w, http.StatusInternalServerError,
+			fmt.Errorf("export stream failed (see server logs)"))
+	default:
+		// Mid-flight failure: headers already out, can only log and
+		// truncate. Client sees a partial response.
 		slog.Warn("audit: export stream failed mid-flight",
 			"err", err,
 			"written", written,
 		)
-	}
-	if flusher != nil {
-		flusher.Flush()
+		if flusher != nil {
+			flusher.Flush()
+		}
 	}
 }
 

--- a/pkg/httpsrv/portal_api.go
+++ b/pkg/httpsrv/portal_api.go
@@ -2,6 +2,7 @@ package httpsrv
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -39,6 +40,7 @@ func (p *PortalAPI) Mount(mux *http.ServeMux, mw func(http.Handler) http.Handler
 	mux.Handle("GET /api/v1/portal/tools/{name}", mw(http.HandlerFunc(p.toolDetail)))
 	mux.Handle("GET /api/v1/portal/audit/events", mw(http.HandlerFunc(p.auditEvents)))
 	mux.Handle("GET /api/v1/portal/audit/events/{id}", mw(http.HandlerFunc(p.auditEventDetail)))
+	mux.Handle("GET /api/v1/portal/audit/export", mw(http.HandlerFunc(p.auditExport)))
 	mux.Handle("GET /api/v1/portal/audit/timeseries", mw(http.HandlerFunc(p.auditTimeseries)))
 	mux.Handle("GET /api/v1/portal/audit/breakdown", mw(http.HandlerFunc(p.auditBreakdown)))
 	mux.Handle("GET /api/v1/portal/dashboard", mw(http.HandlerFunc(p.dashboard)))
@@ -147,6 +149,41 @@ func parseQueryFilter(r *http.Request) audit.QueryFilter {
 	if v, _ := strconv.Atoi(q.Get("offset")); v > 0 {
 		f.Offset = v
 	}
+
+	// JSONB path filters and has= shortcuts. Anything malformed
+	// (unknown source, empty path, unknown has key) is silently dropped
+	// rather than failing the whole query, matching how unknown plain
+	// query params are handled above.
+	for k, vs := range q {
+		switch {
+		case strings.HasPrefix(k, "param."), strings.HasPrefix(k, "response."), strings.HasPrefix(k, "header."):
+			source, rest, ok := strings.Cut(k, ".")
+			if !ok || rest == "" || !audit.IsAllowedJSONSource(source) {
+				continue
+			}
+			path := audit.SplitJSONPath(rest)
+			if len(path) == 0 {
+				continue
+			}
+			for _, v := range vs {
+				if v == "" {
+					continue
+				}
+				f.JSONFilters = append(f.JSONFilters, audit.JSONPathFilter{
+					Source: source,
+					Path:   path,
+					Value:  v,
+				})
+			}
+		case k == "has":
+			for _, v := range vs {
+				if audit.IsAllowedHasKey(v) {
+					f.HasKeys = append(f.HasKeys, v)
+				}
+			}
+		}
+	}
+
 	return f
 }
 
@@ -230,6 +267,90 @@ func (p *PortalAPI) auditEventDetail(w http.ResponseWriter, r *http.Request) {
 
 	writeJSON(w, http.StatusOK, ev)
 }
+
+// maxExportEvents caps the export endpoint at a fixed event count
+// regardless of operator filters, so a misconfigured export can't
+// hold the database open or run an httptest pool out of memory.
+// Operators wanting more should narrow the filter or page through
+// /audit/events directly.
+const maxExportEvents = 100_000
+
+// auditExport streams a filtered slice of events as newline-delimited
+// JSON (jsonl). Filters mirror /audit/events; the only required
+// parameter is format=jsonl (other formats reserved for future).
+//
+// The summary row (no payload) is what's emitted, matching what
+// /events returns. Operators who need the payload should fetch
+// individual events via /audit/events/{id} after filtering.
+func (p *PortalAPI) auditExport(w http.ResponseWriter, r *http.Request) {
+	if got := r.URL.Query().Get("format"); got != "" && got != "jsonl" {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("unsupported format %q (only jsonl is supported)", got))
+		return
+	}
+	f := parseQueryFilter(r)
+	// Limit/Offset apply differently here: Limit caps the export, but
+	// the underlying paginated stream uses its own page size. Map the
+	// caller's Limit (if any) onto a hard ceiling, and clear Offset so
+	// streams always start from the head of the matching set.
+	exportCap := f.Limit
+	if exportCap <= 0 || exportCap > maxExportEvents {
+		exportCap = maxExportEvents
+	}
+	f.Limit = 0
+	f.Offset = 0
+
+	sl, ok := p.audit.(audit.StreamingLogger)
+	if !ok {
+		writeError(w, http.StatusServiceUnavailable, fmt.Errorf("export not supported by configured audit backend"))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/x-ndjson")
+	// Suggest a filename for browser-driven downloads; consumers
+	// piping with curl/jq ignore Content-Disposition.
+	w.Header().Set("Content-Disposition", `attachment; filename="audit.jsonl"`)
+	w.WriteHeader(http.StatusOK)
+
+	enc := json.NewEncoder(w)
+	written := 0
+	flusher, _ := w.(http.Flusher)
+	err := sl.Stream(r.Context(), f, func(ev audit.Event) error {
+		if written >= exportCap {
+			// Bail by returning a sentinel; the closure can't write a
+			// trailer mid-stream once headers are out, so just stop.
+			return errExportCapped
+		}
+		// Payload is summary-only on this endpoint; clear any in-memory
+		// pointer set by the underlying logger before encoding.
+		ev.Payload = nil
+		if err := enc.Encode(&ev); err != nil {
+			return err
+		}
+		written++
+		// Flush every 100 lines so a slow consumer sees data promptly
+		// and a long-running export shows progress.
+		if flusher != nil && written%100 == 0 {
+			flusher.Flush()
+		}
+		return nil
+	})
+	if err != nil && !errors.Is(err, errExportCapped) {
+		// Headers are already out, so we can only log + truncate the
+		// stream. The client will see a partial response.
+		slog.Warn("audit: export stream failed mid-flight",
+			"err", err,
+			"written", written,
+		)
+	}
+	if flusher != nil {
+		flusher.Flush()
+	}
+}
+
+// errExportCapped is the sentinel a Stream callback returns to signal
+// the export hit maxExportEvents (or the operator-supplied cap) and
+// should stop without surfacing as a real error.
+var errExportCapped = errors.New("export cap reached")
 
 // maxTimeseriesWindow caps the requested time-series window at 30 days
 // regardless of bucket size, to bound query cost on the audit table.

--- a/pkg/httpsrv/portal_api_export_test.go
+++ b/pkg/httpsrv/portal_api_export_test.go
@@ -130,3 +130,145 @@ func TestParseQueryFilter_RejectsUnknownSourceAndKey(t *testing.T) {
 		t.Errorf("unknown has key should be rejected, got: %v", f.HasKeys)
 	}
 }
+
+func TestParseQueryFilter_DropsEmptyPathSegments(t *testing.T) {
+	// "?param.a..b=v" parses to path ["a","","b"]: an empty segment
+	// can't match any real payload, so the whole filter is dropped.
+	r := httptest.NewRequest(http.MethodGet,
+		"/api/v1/portal/audit/events?param.a..b=v&param..leading=v&param.trailing.=v",
+		nil)
+	f := parseQueryFilter(r)
+	if len(f.JSONFilters) != 0 {
+		t.Errorf("empty-segment paths should be dropped, got: %+v", f.JSONFilters)
+	}
+}
+
+func TestParseQueryFilter_CanonicalizesHeaderName(t *testing.T) {
+	// Operators routinely write headers in lower-case in URLs. The
+	// stored JSONB carries the canonical Go form (User-Agent), so the
+	// parser must canonicalize before matching.
+	r := httptest.NewRequest(http.MethodGet,
+		"/api/v1/portal/audit/events?header.user-agent=curl/8.0&header.x-api-key=k",
+		nil)
+	f := parseQueryFilter(r)
+	if len(f.JSONFilters) != 2 {
+		t.Fatalf("len = %d, want 2: %+v", len(f.JSONFilters), f.JSONFilters)
+	}
+	got := map[string]string{}
+	for _, jf := range f.JSONFilters {
+		got[jf.Path[0]] = jf.Value
+	}
+	if got["User-Agent"] != "curl/8.0" {
+		t.Errorf("User-Agent canonicalization failed: %+v", got)
+	}
+	if got["X-Api-Key"] != "k" {
+		t.Errorf("X-Api-Key canonicalization failed: %+v", got)
+	}
+}
+
+func TestPortalAPI_AuditEvents_AppliesJSONFilters(t *testing.T) {
+	// /audit/events runs the same parseQueryFilter -> Logger.Query
+	// path; locks the wiring so a refactor that drops f.JSONFilters
+	// or f.HasKeys before forwarding to the logger surfaces here.
+	mem := audit.NewMemoryLogger()
+	now := time.Now().UTC()
+	_ = mem.Log(context.Background(), audit.Event{
+		ID: "alice", ToolName: "echo", Timestamp: now, Success: true,
+		Transport: "http", Source: "mcp",
+		Payload: &audit.Payload{
+			RequestParams:  map[string]any{"user": map[string]any{"id": "alice"}},
+			RequestHeaders: map[string][]string{"User-Agent": {"curl/8.0"}},
+		},
+	})
+	_ = mem.Log(context.Background(), audit.Event{
+		ID: "bob", ToolName: "echo", Timestamp: now.Add(time.Second), Success: false,
+		Transport: "http", Source: "mcp",
+		Payload: &audit.Payload{
+			RequestParams: map[string]any{"user": map[string]any{"id": "bob"}},
+			ResponseError: map[string]any{"category": "tool"},
+		},
+	})
+
+	cases := []struct {
+		name string
+		url  string
+		ids  []string
+	}{
+		{"param path filter", "?param.user.id=alice", []string{"alice"}},
+		{"has= filter", "?has=response_error", []string{"bob"}},
+		{"header case-insensitive", "?header.user-agent=curl/8.0", []string{"alice"}},
+	}
+	mux := portalTestMux(t, mem)
+	for _, c := range cases {
+		req := httptest.NewRequest(http.MethodGet,
+			"/api/v1/portal/audit/events"+c.url, nil)
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Errorf("%s: status = %d body=%s", c.name, w.Code, w.Body.String())
+			continue
+		}
+		var resp struct {
+			Events []audit.Event `json:"events"`
+		}
+		_ = json.NewDecoder(w.Body).Decode(&resp)
+		got := make([]string, 0, len(resp.Events))
+		for _, ev := range resp.Events {
+			got = append(got, ev.ID)
+		}
+		if !equalStringSlice(got, c.ids) {
+			t.Errorf("%s: ids = %v, want %v", c.name, got, c.ids)
+		}
+	}
+}
+
+func TestPortalAPI_AuditExport_HonorsLimitCap(t *testing.T) {
+	// Lock the cap path: with N events stored and ?limit=K (K<N),
+	// the export emits exactly K lines. A regression that flips the
+	// >= comparison or skips the early return would show here.
+	mem := audit.NewMemoryLogger()
+	now := time.Now().UTC()
+	const stored = 10
+	for i := 0; i < stored; i++ {
+		_ = mem.Log(context.Background(), audit.Event{
+			ID:        string(rune('a' + i)),
+			ToolName:  "echo",
+			Timestamp: now.Add(time.Duration(i) * time.Second),
+			Success:   true,
+			Transport: "http",
+			Source:    "mcp",
+		})
+	}
+	mux := portalTestMux(t, mem)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/portal/audit/export?format=jsonl&limit=4", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	var lines int
+	scanner := bufio.NewScanner(w.Body)
+	for scanner.Scan() {
+		if scanner.Text() != "" {
+			lines++
+		}
+	}
+	if lines != 4 {
+		t.Errorf("limit=4 with %d events stored: got %d lines, want 4", stored, lines)
+	}
+}
+
+// equalStringSlice is a small set-or-order-insensitive helper local
+// to this file; tests don't share helpers across files in this package.
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/httpsrv/portal_api_export_test.go
+++ b/pkg/httpsrv/portal_api_export_test.go
@@ -292,15 +292,31 @@ func TestPortalAPI_AuditExport_HonorsLimitCap(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
 	}
-	var lines int
+	// Documented contract: exports start from the head of the matching
+	// set (newest first by ts DESC). With ts increasing per i, the
+	// newest 4 ids are the last-inserted 4. Assert both the count and
+	// the order so a regression that shipped tail-of-set instead of
+	// head would surface.
+	var ids []string
 	scanner := bufio.NewScanner(w.Body)
 	for scanner.Scan() {
-		if scanner.Text() != "" {
-			lines++
+		line := scanner.Text()
+		if line == "" {
+			continue
 		}
+		var ev struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			t.Fatalf("line not JSON: %v\n%s", err, line)
+		}
+		ids = append(ids, ev.ID)
 	}
-	if lines != 4 {
-		t.Errorf("limit=4 with %d events stored: got %d lines, want 4", stored, lines)
+	// ids 'a','b','c','d','e','f','g','h','i','j' inserted at
+	// ts=now+0..9s. Newest 4 by ts DESC: j, i, h, g.
+	want := []string{"j", "i", "h", "g"}
+	if !equalStringSlice(ids, want) {
+		t.Errorf("limit=4 emitted ids = %v, want %v (head of matching set, ts DESC)", ids, want)
 	}
 }
 

--- a/pkg/httpsrv/portal_api_export_test.go
+++ b/pkg/httpsrv/portal_api_export_test.go
@@ -1,0 +1,132 @@
+package httpsrv
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/plexara/mcp-test/pkg/audit"
+)
+
+// TestPortalAPI_AuditExport_StreamsNDJSON exercises the new
+// /audit/export?format=jsonl endpoint against the in-memory logger.
+// Each line should be a valid JSON event; payload (when set on the
+// stored event) must be cleared in the export view.
+func TestPortalAPI_AuditExport_StreamsNDJSON(t *testing.T) {
+	mem := audit.NewMemoryLogger()
+	now := time.Now().UTC()
+	for i := 0; i < 3; i++ {
+		_ = mem.Log(context.Background(), audit.Event{
+			ID:        string(rune('a' + i)),
+			ToolName:  "echo",
+			Timestamp: now.Add(time.Duration(i) * time.Second),
+			Success:   true,
+			Transport: "http",
+			Source:    "mcp",
+			Payload:   &audit.Payload{JSONRPCMethod: "tools/call"},
+		})
+	}
+
+	mux := portalTestMux(t, mem)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/portal/audit/export?format=jsonl", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/x-ndjson" {
+		t.Errorf("Content-Type = %q, want application/x-ndjson", ct)
+	}
+	scanner := bufio.NewScanner(w.Body)
+	count := 0
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		var ev map[string]any
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			t.Fatalf("line %d not valid JSON: %v\n%s", count, err, line)
+		}
+		if _, hasPayload := ev["payload"]; hasPayload {
+			t.Errorf("line %d carried payload; export should be summary-only: %s", count, line)
+		}
+		count++
+	}
+	if count != 3 {
+		t.Errorf("got %d lines, want 3", count)
+	}
+}
+
+func TestPortalAPI_AuditExport_RejectsUnknownFormat(t *testing.T) {
+	mux := portalTestMux(t, audit.NewMemoryLogger())
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/portal/audit/export?format=csv", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "unsupported format") {
+		t.Errorf("body = %s", w.Body.String())
+	}
+}
+
+func TestPortalAPI_AuditExport_DefaultsToJSONLWhenFormatOmitted(t *testing.T) {
+	// No `format=` param at all should be allowed and treated as jsonl
+	// (the only format we support today). Documented in http-api.md.
+	mux := portalTestMux(t, audit.NewMemoryLogger())
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/portal/audit/export", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+}
+
+func TestParseQueryFilter_JSONFilters(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet,
+		"/api/v1/portal/audit/events?param.user.id=alice&response.isError=true&header.User-Agent=curl/8.0&has=response_error&has=notifications",
+		nil)
+	f := parseQueryFilter(r)
+
+	if len(f.JSONFilters) != 3 {
+		t.Fatalf("JSONFilters len = %d, want 3: %+v", len(f.JSONFilters), f.JSONFilters)
+	}
+	// Verify each filter resolved correctly. Order isn't guaranteed
+	// (URL.Query is a map), so check by source.
+	got := map[string]audit.JSONPathFilter{}
+	for _, jf := range f.JSONFilters {
+		got[jf.Source] = jf
+	}
+	if p := got["param"]; len(p.Path) != 2 || p.Path[0] != "user" || p.Path[1] != "id" || p.Value != "alice" {
+		t.Errorf("param filter wrong: %+v", p)
+	}
+	if r := got["response"]; len(r.Path) != 1 || r.Path[0] != "isError" || r.Value != "true" {
+		t.Errorf("response filter wrong: %+v", r)
+	}
+	if h := got["header"]; len(h.Path) != 1 || h.Path[0] != "User-Agent" || h.Value != "curl/8.0" {
+		t.Errorf("header filter wrong: %+v", h)
+	}
+	if len(f.HasKeys) != 2 {
+		t.Errorf("HasKeys = %v, want 2", f.HasKeys)
+	}
+}
+
+func TestParseQueryFilter_RejectsUnknownSourceAndKey(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet,
+		"/api/v1/portal/audit/events?evil.k=v&has=secret_table",
+		nil)
+	f := parseQueryFilter(r)
+	if len(f.JSONFilters) != 0 {
+		t.Errorf("unknown source should be rejected, got: %+v", f.JSONFilters)
+	}
+	if len(f.HasKeys) != 0 {
+		t.Errorf("unknown has key should be rejected, got: %v", f.HasKeys)
+	}
+}

--- a/pkg/httpsrv/portal_api_export_test.go
+++ b/pkg/httpsrv/portal_api_export_test.go
@@ -222,6 +222,51 @@ func TestPortalAPI_AuditEvents_AppliesJSONFilters(t *testing.T) {
 	}
 }
 
+func TestPortalAPI_AuditExport_DoesNotEscapeHTMLChars(t *testing.T) {
+	// SetEscapeHTML(false) on the encoder: tool output containing
+	// <, >, & must hit the wire unescaped so an operator eyeballing
+	// the JSONL file sees the original bytes. Standard json.Encoder
+	// would emit "<" etc., which is technically valid JSON but
+	// surprising in a human-readable export.
+	mem := audit.NewMemoryLogger()
+	_ = mem.Log(context.Background(), audit.Event{
+		ID:           "html-event",
+		ToolName:     "echo",
+		Timestamp:    time.Now().UTC(),
+		Success:      true,
+		Transport:    "http",
+		Source:       "mcp",
+		ErrorMessage: "<script>alert(\"x\")</script> & friends",
+	})
+
+	mux := portalTestMux(t, mem)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/portal/audit/export?format=jsonl", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	body := w.Body.String()
+	// With Go's default encoder, '<' is emitted as the 6-byte unicode
+	// escape "<", '>' as ">", '&' as "&".
+	// SetEscapeHTML(false) lets the raw bytes through. Assert the raw
+	// form, fail on any of the escape forms.
+	escapes := []string{
+		"\\u003c", // <
+		"\\u003e", // >
+		"\\u0026", // &
+	}
+	for _, esc := range escapes {
+		if strings.Contains(body, esc) {
+			t.Errorf("SetEscapeHTML(false) regression: body still has %q escape:\n%s", esc, body)
+		}
+	}
+	if !strings.Contains(body, "<script>") {
+		t.Errorf("expected raw '<script>' in body, got:\n%s", body)
+	}
+}
+
 func TestPortalAPI_AuditExport_HonorsLimitCap(t *testing.T) {
 	// Lock the cap path: with N events stored and ?limit=K (K<N),
 	// the export emits exactly K lines. A regression that flips the

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -80,19 +80,30 @@ func TestIntegration_WhoamiOverHTTP(t *testing.T) {
 		t.Errorf("auth_type = %v, want apikey", sc["auth_type"])
 	}
 
-	// Audit assertions: pull the events back from Postgres.
+	// Audit assertions: pull the events back from Postgres. The audit
+	// pipeline is async-buffered (AsyncLogger), so the row may not be
+	// visible the instant CallTool returns. Poll briefly.
 	pool, err := pgxpool.New(ctx, pgURL)
 	if err != nil {
 		t.Fatalf("pgx pool: %v", err)
 	}
 	t.Cleanup(pool.Close)
 	store := auditpg.New(pool)
-	events, err := store.Query(ctx, audit.QueryFilter{Limit: 10})
-	if err != nil {
-		t.Fatalf("audit query: %v", err)
+
+	var events []audit.Event
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		events, err = store.Query(ctx, audit.QueryFilter{Limit: 10})
+		if err != nil {
+			t.Fatalf("audit query: %v", err)
+		}
+		if len(events) >= 1 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
 	}
 	if len(events) != 1 {
-		t.Fatalf("audit events = %d, want 1", len(events))
+		t.Fatalf("audit events = %d, want 1 (after 2s poll)", len(events))
 	}
 	if events[0].ToolName != "whoami" {
 		t.Errorf("audit tool name = %q, want whoami", events[0].ToolName)


### PR DESCRIPTION
First slice of the v1.1.1 follow-up under [#8](https://github.com/plexara/mcp-test/issues/8). Lands the query-side improvements that operators wanted before the portal UI rewrite: JSONB-aware filters that hit the existing GIN indexes, and a streaming NDJSON export. Replay, SSE live tail, the inspection drawer, and comparison page land in subsequent PRs on top of this.

## What's in this PR

### Filter surface (`/audit/events`, `/audit/export`)

Operators can now narrow the audit query by values inside the `audit_payloads` sibling row, not just the indexed summary columns:

```
?param.<dotted.path>=<value>     -> request_params @> {...}
?response.<dotted.path>=<value>  -> response_result @> {...}
?header.<name>=<value>           -> request_headers @> {name:[value]}
?has=<column>                    -> column IS NOT NULL
```

- Each filter compiles to an `EXISTS (SELECT 1 FROM audit_payloads p WHERE p.event_id = audit_events.id AND p.<col> @> $N::jsonb)` subquery, so it hits the existing `jsonb_path_ops` GIN indexes on `request_params` and `response_result`. `request_headers` is unindexed today; pair `header.*` with a time range.
- Closed allow-lists (`audit.AllowedHasKeys`, `audit.AllowedJSONSources`) gate column and source names. The HTTP layer drops anything outside the lists silently rather than 400-ing, matching how unknown plain query params are handled.
- Values are type-detected before the containment doc is built: `true` / `false` become JSON booleans, integer / float strings become numbers, quoted forms force string. So `?response.isError=true` matches the JSON literal `true`, and `?param.code="200"` forces the string `"200"`.
- Filters are AND-combined with each other and with the existing indexed-column filters (`tool`, `user`, `success`, `from`, `to`, `q`, etc.).

### NDJSON export (`GET /api/v1/portal/audit/export?format=jsonl`)

- Same filter surface as `/audit/events`; `format=jsonl` is the default and only supported format today (`csv` etc. reserved, returns 400).
- Streams via the new `audit.StreamingLogger` capability. The Postgres store paginates `buildSelect` at 1000 rows/page so memory stays bounded; the MemoryLogger iterates a Query result (cheap, but matches the contract); NoopLogger is a no-op.
- Hard cap at 100,000 events per request to bound query cost and response time. Operators wanting more should narrow the filter window or page through `/events`.
- `http.Flusher` flushes every 100 lines so a long export shows progress to the consumer immediately.
- Summary rows only; the captured `audit_payloads` envelope is omitted from each line. Pull full payloads via `/audit/events/{id}` after filtering.
- Sets `Content-Type: application/x-ndjson` and `Content-Disposition: attachment; filename="audit.jsonl"` for browser-driven downloads; `curl | jq` consumers ignore the disposition.

### New audit package surface

- `audit.QueryFilter` gains `JSONFilters []JSONPathFilter` and `HasKeys []string`.
- `audit.JSONPathFilter` is `{Source, Path, Value}` where Source is one of `"param"` / `"response"` / `"header"`.
- `audit.AllowedHasKeys` and `audit.AllowedJSONSources` expose the closed sets so the HTTP layer can validate.
- `pkg/audit/jsonfilter.go` is the shared compiler used by both backends: `ParseJSONFilterValue` (type detection), `JSONFilterToContainment` (dotted path to nested map), `MatchJSONPath` (memory-side traversal with JSON-semantic equality), `SplitJSONPath`, `IsAllowedHasKey`, `IsAllowedJSONSource`.
- `audit.StreamingLogger`: optional capability, type-asserted by the export endpoint, with a graceful fallback through `AsyncLogger.Stream` to a bounded `Query`.

### Drive-by

`tests/integration_test.go::TestIntegration_WhoamiOverHTTP` was a pre-existing timing flake under `-race`: it queried Postgres for the audit row before `AsyncLogger`'s background drain had flushed. Surfaced consistently while running the integration suite for this branch. Adds a 2-second poll loop. No related code change; just makes the assertion patient enough for the race-detector slowdown.

## Tests

| File | Coverage |
|---|---|
| `pkg/audit/jsonfilter_test.go` | `ParseJSONFilterValue` type detection (bool, int, float, forced-string, plain), `JSONFilterToContainment` (empty path, single, nested), `MatchJSONPath` (numeric widening, missing path, scalar dead-end), `SplitJSONPath`, `IsAllowedHasKey` allow/reject |
| `pkg/audit/memory_test.go` | `JSONFilters` + `HasKeys` matching against `Event.Payload` (param path, response bool, header value, has-shortcut, AND combination); `Stream` returns Query order |
| `pkg/audit/postgres/store_test.go` (testcontainer-tagged) | every JSONFilter / HasKey case from the memory test repeated against real Postgres so the GIN-index + EXISTS-subquery path is exercised end-to-end; new 1100-event `Stream` test that proves the page-loop iterates past the 1000-row internal page boundary |
| `pkg/httpsrv/portal_api_export_test.go` | `/audit/export?format=jsonl` returns one line per event with payload omitted; unknown format gets 400; missing format defaults to jsonl; `parseQueryFilter` parses the four new syntaxes (`param.*`, `response.*`, `header.*`, `has=`) and rejects unknown sources / has-keys |

## Docs

- `docs/reference/http-api.md`: new rows for `/audit/events/{id}` and `/audit/export`. New "JSONB path filters" section: syntax table, type-detection rule, index notes (which filters are GIN-backed, which scan).
- `docs/operations/audit.md`: new "Two-table layout" section explaining the `audit_events` / `audit_payloads` split that landed in v1.1.0; updated REST endpoints table; new "JSONB filters" subsection with curl examples for the four common cases (param path, response shape, header match, has-key); new "NDJSON export" subsection with a curl-piped-through-jq example.

## Closes (subtasks of #8)

- [x] **JSONB path filter compiler.** Compiles to safe parameterized SQL using the existing GIN indexes.
- [x] **NDJSON export.** Filters mirror /events; streams.

Does not close the umbrella issue. Remaining subtasks (replay endpoint, SSE live tail, portal UI inspection drawer, comparison page, `docs/operations/inspection.md` walkthrough) land in subsequent PRs per the focused-PR plan.

## Verification

- `make verify` green: gofmt, vet, race-tested unit suite, golangci-lint v2.11.4, gosec v2.25.0, govulncheck, semgrep, coverage gate (80.0%, gate is 80%).
- `go test -tags integration -count=1 -timeout 300s ./...` green: testcontainers Postgres exercises the JSONB filter compiler and the streaming pagination; the full HTTP stack tests pass.

## Test plan

- [x] `make verify` green
- [x] tagged integration tests green
- [ ] Manual: bring up `make dev`, fire a few `progress` and `echo` calls, then:
  - `curl -H "X-API-Key: $KEY" "$BASE/api/v1/portal/audit/events?param.message=hello"` returns only the matching `echo` calls
  - `curl -H "X-API-Key: $KEY" "$BASE/api/v1/portal/audit/events?response.isError=true"` returns only error responses
  - `curl -H "X-API-Key: $KEY" "$BASE/api/v1/portal/audit/events?has=notifications"` returns only progress-tool calls
  - `curl -H "X-API-Key: $KEY" "$BASE/api/v1/portal/audit/export?from=$(date -u -v-1H +%FT%TZ)" | wc -l` returns the count of last-hour events
  - `curl -H "X-API-Key: $KEY" "$BASE/api/v1/portal/audit/export?format=csv"` returns 400 with a clear message