### PR TITLE
docs: v1.2 followups — table-to-card layouts, K8s example, social-card SEO

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,10 +32,23 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install system deps for mkdocs-material social cards
+        # The social plugin renders per-page OG images (1200x630) via
+        # cairosvg + Pillow. cairosvg needs the system libcairo, libffi,
+        # and libjpeg libraries.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev
+
       - name: Install dependencies
+        env:
+          # mkdocs-material[imaging] pulls in cairosvg + pillow so the
+          # `social` plugin can run.
+          PIP_DISABLE_PIP_VERSION_CHECK: "1"
         run: |
           pip install \
-            mkdocs-material \
+            'mkdocs-material[imaging]' \
             'pymdown-extensions>=10.0'
 
       - name: Build documentation

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -16,19 +16,150 @@ plus a few un-prefixed standard names (`LOG_LEVEL`).
 
 ## Common overrides
 
-| Variable | Used by | Example |
-| --- | --- | --- |
-| `LOG_LEVEL` | Binary | `debug`, `info` (default), `warn`, `error`. |
-| `MCPTEST_PORT` | `server.address` | `8080` |
-| `MCPTEST_BASE_URL` | `server.base_url` | `https://mcp-test.example.com` |
-| `MCPTEST_DATABASE_URL` | `database.url` | `postgres://mcp:mcp@localhost:5432/mcp_test?sslmode=disable` |
-| `MCPTEST_DEV_KEY` | `api_keys.file[0].key` | `devkey-please-change` |
-| `MCPTEST_OIDC_ISSUER` | `oidc.issuer` | `http://localhost:8081/realms/mcp-test` |
-| `MCPTEST_OIDC_AUDIENCE` | `oidc.audience` | `mcp-test` |
-| `MCPTEST_OIDC_CLIENT_ID` | `oidc.client_id` | `mcp-test-portal` |
-| `MCPTEST_OIDC_CLIENT_SECRET` | `oidc.client_secret` | (confidential clients only) |
-| `MCPTEST_COOKIE_SECRET` | `portal.cookie_secret` | 32+ bytes, base64 |
-| `MCPTEST_INSECURE` | OIDC skip-signature gate | `1` to allow `oidc.skip_signature_verification` |
+<div class="config-keys" markdown>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">LOG_LEVEL</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">used by</span><span class="config-key__chip-value">binary</span></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+`debug`, `info` (default), `warn`, `error`. Sets the slog log level for the whole process.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">MCPTEST_PORT</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">maps to</span><code class="config-key__chip-value">server.address</code></span>
+<span class="config-key__chip"><span class="config-key__chip-label">example</span><code class="config-key__chip-value">8080</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+The live config interpolates as `:${MCPTEST_PORT:-8080}`.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">MCPTEST_BASE_URL</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">maps to</span><code class="config-key__chip-value">server.base_url</code></span>
+<span class="config-key__chip"><span class="config-key__chip-label">example</span><code class="config-key__chip-value">https://mcp-test.example.com</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+The public origin clients reach the server at. Used in OIDC redirect URIs and the protected-resource metadata document.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">MCPTEST_DATABASE_URL</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">maps to</span><code class="config-key__chip-value">database.url</code></span>
+<span class="config-key__chip"><span class="config-key__chip-label">example</span><code class="config-key__chip-value">postgres://mcp:mcp@localhost:5432/mcp_test?sslmode=disable</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+A pgx-compatible Postgres DSN.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">MCPTEST_DEV_KEY</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">maps to</span><code class="config-key__chip-value">api_keys.file[0].key</code></span>
+<span class="config-key__chip"><span class="config-key__chip-label">example</span><code class="config-key__chip-value">devkey-please-change</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+The bootstrap file API key. Sent as `X-API-Key`.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">MCPTEST_OIDC_ISSUER</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">maps to</span><code class="config-key__chip-value">oidc.issuer</code></span>
+<span class="config-key__chip"><span class="config-key__chip-label">example</span><code class="config-key__chip-value">http://localhost:8081/realms/mcp-test</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Required when OIDC is enabled.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">MCPTEST_OIDC_AUDIENCE</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">maps to</span><code class="config-key__chip-value">oidc.audience</code></span>
+<span class="config-key__chip"><span class="config-key__chip-label">example</span><code class="config-key__chip-value">mcp-test</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Required `aud` claim value.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">MCPTEST_OIDC_CLIENT_ID</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">maps to</span><code class="config-key__chip-value">oidc.client_id</code></span>
+<span class="config-key__chip"><span class="config-key__chip-label">example</span><code class="config-key__chip-value">mcp-test-portal</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+The OIDC client ID used by the browser PKCE login flow.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">MCPTEST_OIDC_CLIENT_SECRET</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">maps to</span><code class="config-key__chip-value">oidc.client_secret</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Confidential clients only; public PKCE clients leave it empty.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">MCPTEST_COOKIE_SECRET</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">maps to</span><code class="config-key__chip-value">portal.cookie_secret</code></span>
+<span class="config-key__chip"><span class="config-key__chip-label">example</span><span class="config-key__chip-value">32+ bytes, base64</span></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+HMAC key for the portal session cookie. Generate with `openssl rand -base64 32`.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">MCPTEST_INSECURE</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">used by</span><span class="config-key__chip-value">OIDC skip-signature gate</span></span>
+<span class="config-key__chip"><span class="config-key__chip-label">example</span><code class="config-key__chip-value">1</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Set to `1` to allow `oidc.skip_signature_verification` (refused otherwise).
+</div>
+</div>
+
+</div>
 
 ## Interpolation rules
 

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -36,21 +36,178 @@ server:
     json_response: false
 ```
 
-| Key | Type | Default | Notes |
-| --- | --- | --- | --- |
-| `server.name` | string | `mcp-test` | Reported in the MCP `initialize` response and in the audit log. |
-| `server.address` | string | `:8080` | Listen address; `MCPTEST_PORT` env interpolation common. |
-| `server.base_url` | string | `http://localhost:<port>` | Public origin used for the protected-resource metadata document and OIDC redirect URIs. Set this to your real hostname behind TLS terminators. |
-| `server.instructions` | string | (project default, see [Server Instructions](instructions.md)) | Returned to MCP clients via `initialize.result.instructions`. Most clients pass this to the LLM as system context. |
-| `server.read_header_timeout` | duration | `10s` | Standard `http.Server.ReadHeaderTimeout`. |
-| `server.shutdown.grace_period` | duration | `25s` | Maximum time `http.Server.Shutdown` waits for in-flight requests during drain. |
-| `server.shutdown.pre_shutdown_delay` | duration | `2s` | After SIGINT/SIGTERM, the server flips `/readyz` to 503 and sleeps this long before starting the shutdown so load balancers notice. |
-| `server.tls.enabled` | bool | `false` | If true, listens with TLS using the cert/key files below. Most deployments terminate TLS upstream and leave this false. |
-| `server.tls.cert_file` | string | `""` | PEM-encoded certificate path. |
-| `server.tls.key_file` | string | `""` | PEM-encoded private key path. |
-| `server.streamable.session_timeout` | duration | `30m` | Idle MCP session timeout passed to `mcp.StreamableHTTPOptions`. |
-| `server.streamable.stateless` | bool | `false` | If true, the SDK does not validate `Mcp-Session-Id` and uses ephemeral sessions. Useful behind external session stores; we don't ship one. |
-| `server.streamable.json_response` | bool | `false` | If true, responses are `application/json` instead of `text/event-stream`. |
+<div class="config-keys" markdown>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">server.name</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">string</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">mcp-test</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Reported in the MCP `initialize` response and in the audit log.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">server.address</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">string</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">:8080</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Listen address; `MCPTEST_PORT` env interpolation common.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">server.base_url</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">string</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">http://localhost:&lt;port&gt;</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Public origin used for the protected-resource metadata document and OIDC redirect URIs. Set this to your real hostname behind TLS terminators.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">server.instructions</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">string</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><span class="config-key__chip-value">project default</span></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Returned to MCP clients via `initialize.result.instructions`. Most clients pass this to the LLM as system context. See [Server Instructions](instructions.md) for the shipped default.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">server.read_header_timeout</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">duration</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">10s</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Standard `http.Server.ReadHeaderTimeout`.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">server.shutdown.grace_period</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">duration</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">25s</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Maximum time `http.Server.Shutdown` waits for in-flight requests during drain.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">server.shutdown.pre_shutdown_delay</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">duration</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">2s</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+After SIGINT / SIGTERM, the server flips `/readyz` to 503 and sleeps this long before starting the shutdown so load balancers notice.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">server.tls.enabled</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">bool</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">false</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+If true, listens with TLS using the cert / key files below. Most deployments terminate TLS upstream and leave this false.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">server.tls.cert_file</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">string</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">""</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+PEM-encoded certificate path.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">server.tls.key_file</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">string</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">""</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+PEM-encoded private key path.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">server.streamable.session_timeout</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">duration</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">30m</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Idle MCP session timeout passed to `mcp.StreamableHTTPOptions`.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">server.streamable.stateless</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">bool</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">false</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+If true, the SDK does not validate `Mcp-Session-Id` and uses ephemeral sessions. Useful behind external session stores; we don't ship one.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">server.streamable.json_response</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">bool</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">false</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+If true, responses are `application/json` instead of `text/event-stream`.
+</div>
+</div>
+
+</div>
 
 ## oidc
 
@@ -70,17 +227,126 @@ oidc:
   skip_signature_verification: false
 ```
 
-| Key | Type | Default | Notes |
-| --- | --- | --- | --- |
-| `oidc.enabled` | bool | `false` | Master toggle. With it off, only API keys (file/DB) and anonymous mode (if enabled) authenticate. |
-| `oidc.issuer` | string | `""` | Required when enabled. The IdP's issuer URL; mcp-test fetches `<issuer>/.well-known/openid-configuration` to find the JWKS and authorization endpoints. |
-| `oidc.audience` | string | `""` | Required `aud` claim value. Tokens that don't carry this audience are rejected. |
-| `oidc.client_id` | string | `""` | The OIDC client ID used by the browser PKCE login flow. |
-| `oidc.client_secret` | string | `""` | Optional. Confidential clients should set this; public PKCE clients leave it empty. |
-| `oidc.allowed_clients` | []string | `[]` | Optional `azp` / `client_id` allowlist. Empty means any client of the issuer is accepted. |
-| `oidc.clock_skew_seconds` | int | `30` | Leeway applied when validating `exp` / `iat` / `nbf`. |
-| `oidc.jwks_cache_ttl` | duration | `1h` | How long fetched JWKS keys are cached. The cache transparently refreshes on any unknown `kid`. |
-| `oidc.skip_signature_verification` | bool | `false` | Trust the IdP's TLS without verifying JWT signatures. Refused unless `MCPTEST_INSECURE=1` is set in the environment. |
+<div class="config-keys" markdown>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">oidc.enabled</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">bool</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">false</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Master toggle. With it off, only API keys (file / DB) and anonymous mode (if enabled) authenticate.
+</div>
+</div>
+
+<div class="config-key config-key--required" markdown>
+<div class="config-key__head">
+<code class="config-key__name">oidc.issuer</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">string</span></span>
+<span class="config-key__chip config-key__chip--required"><span class="config-key__chip-label">required when</span><span class="config-key__chip-value">oidc.enabled</span></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+The IdP's issuer URL. mcp-test fetches `<issuer>/.well-known/openid-configuration` to find the JWKS and authorization endpoints.
+</div>
+</div>
+
+<div class="config-key config-key--required" markdown>
+<div class="config-key__head">
+<code class="config-key__name">oidc.audience</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">string</span></span>
+<span class="config-key__chip config-key__chip--required"><span class="config-key__chip-label">required when</span><span class="config-key__chip-value">oidc.enabled</span></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Required `aud` claim value. Tokens that don't carry this audience are rejected.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">oidc.client_id</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">string</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">""</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+The OIDC client ID used by the browser PKCE login flow.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">oidc.client_secret</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">string</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">""</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Optional. Confidential clients should set this; public PKCE clients leave it empty.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">oidc.allowed_clients</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">[]string</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">[]</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Optional `azp` / `client_id` allowlist. Empty means any client of the issuer is accepted.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">oidc.clock_skew_seconds</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">int</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">30</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Leeway applied when validating `exp` / `iat` / `nbf`.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">oidc.jwks_cache_ttl</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">duration</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">1h</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+How long fetched JWKS keys are cached. The cache transparently refreshes on any unknown `kid`.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">oidc.skip_signature_verification</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">bool</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">false</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Trust the IdP's TLS without verifying JWT signatures. Refused unless `MCPTEST_INSECURE=1` is set in the environment.
+</div>
+</div>
+
+</div>
 
 See [Authentication](auth.md) for the full identity model and
 auth-chain semantics.
@@ -99,10 +365,35 @@ api_keys:
     enabled: true
 ```
 
-| Key | Type | Default | Notes |
-| --- | --- | --- | --- |
-| `api_keys.file` | []entry | `[]` | List of `{name, key, description}` entries. The plaintext `key` is constant-time compared against the inbound `X-API-Key` header. Empty `key` values are skipped (so an unset env var doesn't enable an empty credential). |
-| `api_keys.db.enabled` | bool | `false` | If true, the binary opens the bcrypt-hashed `api_keys` Postgres table for read+write. The portal's API Keys page manages entries. |
+<div class="config-keys" markdown>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">api_keys.file</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">[]entry</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">[]</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+List of `{name, key, description}` entries. The plaintext `key` is constant-time compared against the inbound `X-API-Key` header. Empty `key` values are skipped (so an unset env var doesn't enable an empty credential).
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">api_keys.db.enabled</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">bool</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">false</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+If true, the binary opens the bcrypt-hashed `api_keys` Postgres table for read+write. The portal's API Keys page manages entries.
+</div>
+</div>
+
+</div>
 
 Both sources contribute to the same auth chain: an inbound API key is
 matched against file entries first (cheap O(N) constant-time compare),
@@ -119,11 +410,48 @@ auth:
   require_for_portal: true
 ```
 
-| Key | Type | Default | Notes |
-| --- | --- | --- | --- |
-| `auth.allow_anonymous` | bool | `false` | If true, missing credentials on `/mcp` resolve to a synthetic Anonymous identity. Useful for some gateway tests where you want to validate header pass-through without auth in the way. The portal still requires a credential. |
-| `auth.require_for_mcp` | bool | `true` | Gate the `/` endpoint. Currently the auth gateway checks for credential *presence* and 401s without one (unless anonymous is allowed). |
-| `auth.require_for_portal` | bool | `true` | Gate every `/portal/*` and `/api/v1/*` route. The portal auth middleware is independent of `allow_anonymous`. |
+<div class="config-keys" markdown>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">auth.allow_anonymous</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">bool</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">false</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+If true, missing credentials on `/mcp` resolve to a synthetic Anonymous identity. Useful for some gateway tests where you want to validate header pass-through without auth in the way. The portal still requires a credential.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">auth.require_for_mcp</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">bool</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">true</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Gate the `/` endpoint. Currently the auth gateway checks for credential *presence* and 401s without one (unless anonymous is allowed).
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">auth.require_for_portal</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">bool</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">true</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Gate every `/portal/*` and `/api/v1/*` route. The portal auth middleware is independent of `allow_anonymous`.
+</div>
+</div>
+
+</div>
 
 ## database
 
@@ -138,12 +466,61 @@ database:
   conn_max_lifetime: 1h
 ```
 
-| Key | Type | Default | Notes |
-| --- | --- | --- | --- |
-| `database.url` | string | (required) | A PostgreSQL DSN that the pgx driver understands. The migration runner rewrites `postgres://` to `pgx5://` internally so the golang-migrate driver picks it up. |
-| `database.max_open_conns` | int | `25` | Max active connections in the pgxpool. |
-| `database.max_idle_conns` | int | `5` | Min idle connections held open. |
-| `database.conn_max_lifetime` | duration | `1h` | Recycle connections older than this. |
+<div class="config-keys" markdown>
+
+<div class="config-key config-key--required" markdown>
+<div class="config-key__head">
+<code class="config-key__name">database.url</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">string</span></span>
+<span class="config-key__chip config-key__chip--required"><span class="config-key__chip-label">required</span><span class="config-key__chip-value">always</span></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+A PostgreSQL DSN that the pgx driver understands. The migration runner rewrites `postgres://` to `pgx5://` internally so the golang-migrate driver picks it up.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">database.max_open_conns</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">int</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">25</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Max active connections in the pgxpool.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">database.max_idle_conns</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">int</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">5</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Min idle connections held open.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">database.conn_max_lifetime</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">duration</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">1h</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Recycle connections older than this.
+</div>
+</div>
+
+</div>
 
 See [Database & Migrations](database.md) for the schema details.
 
@@ -158,11 +535,48 @@ audit:
   redact_keys: [password, token, secret, authorization, cookie, api_key, credentials]
 ```
 
-| Key | Type | Default | Notes |
-| --- | --- | --- | --- |
-| `audit.enabled` | bool | `true` | Disables the audit pipeline entirely when false (no rows written, no portal data). |
-| `audit.retention_days` | int | `30` | Documented retention target. mcp-test does not currently auto-prune; deploy a cron job against the `audit_events` table if you need it. |
-| `audit.redact_keys` | []string | `[password, token, secret, authorization, api_key, credentials]` | Case-insensitive substring match. Any tool-call argument key matching one of these gets its value replaced with `[redacted]` before the row is written. |
+<div class="config-keys" markdown>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">audit.enabled</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">bool</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">true</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Disables the audit pipeline entirely when false (no rows written, no portal data).
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">audit.retention_days</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">int</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">30</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Documented retention target. mcp-test does not currently auto-prune; deploy a cron job against the `audit_events` table if you need it.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">audit.redact_keys</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">[]string</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">[password, token, secret, authorization, api_key, credentials]</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Case-insensitive substring match. Any tool-call argument key matching one of these gets its value replaced with `[redacted]` before the row is written.
+</div>
+</div>
+
+</div>
 
 ## portal
 
@@ -177,13 +591,74 @@ portal:
   oidc_redirect_path: /portal/auth/callback
 ```
 
-| Key | Type | Default | Notes |
-| --- | --- | --- | --- |
-| `portal.enabled` | bool | `false` | Master toggle. Disabling skips loading the session store and mounting the portal/admin APIs and SPA. |
-| `portal.cookie_name` | string | `mcp_test_session` | Name of the HMAC-signed session cookie. |
-| `portal.cookie_secret` | string | (required when enabled) | At least 16 bytes, 32+ recommended. HMAC key for cookie signing. |
-| `portal.cookie_secure` | bool | `true` | Sets the `Secure` cookie attribute. Leave on in production; turn off for local HTTP-only dev. |
-| `portal.oidc_redirect_path` | string | `/portal/auth/callback` | OIDC redirect URI path; whatever you set must match what the IdP has registered for the portal client. |
+<div class="config-keys" markdown>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">portal.enabled</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">bool</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">false</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Master toggle. Disabling skips loading the session store and mounting the portal / admin APIs and SPA.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">portal.cookie_name</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">string</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">mcp_test_session</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Name of the HMAC-signed session cookie.
+</div>
+</div>
+
+<div class="config-key config-key--required" markdown>
+<div class="config-key__head">
+<code class="config-key__name">portal.cookie_secret</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">string</span></span>
+<span class="config-key__chip config-key__chip--required"><span class="config-key__chip-label">required when</span><span class="config-key__chip-value">portal.enabled</span></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+At least 16 bytes, 32+ recommended. HMAC key for cookie signing.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">portal.cookie_secure</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">bool</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">true</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Sets the `Secure` cookie attribute. Leave on in production; turn off for local HTTP-only dev.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">portal.oidc_redirect_path</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">string</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">/portal/auth/callback</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+OIDC redirect URI path. Whatever you set must match what the IdP has registered for the portal client.
+</div>
+</div>
+
+</div>
 
 ## tools
 
@@ -197,12 +672,61 @@ tools:
   streaming: { enabled: true }
 ```
 
-| Key | Type | Default | Notes |
-| --- | --- | --- | --- |
-| `tools.identity.enabled` | bool | `false` | `whoami`, `echo`, `headers`. |
-| `tools.data.enabled` | bool | `false` | `fixed_response`, `sized_response`, `lorem`. |
-| `tools.failure.enabled` | bool | `false` | `error`, `slow`, `flaky`. |
-| `tools.streaming.enabled` | bool | `false` | `progress`, `long_output`, `chatty`. |
+<div class="config-keys" markdown>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">tools.identity.enabled</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">bool</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">false</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+`whoami`, `echo`, `headers`.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">tools.data.enabled</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">bool</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">false</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+`fixed_response`, `sized_response`, `lorem`.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">tools.failure.enabled</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">bool</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">false</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+`error`, `slow`, `flaky`.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">tools.streaming.enabled</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">bool</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">false</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+`progress`, `long_output`, `chatty`.
+</div>
+</div>
+
+</div>
 
 A toolkit must be enabled in config for its tools to be registered
 with the MCP server. The example and dev configs enable all four.

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -11,15 +11,58 @@ fronted by an OIDC provider (for bearer-token auth and portal login).
 
 ## What you get
 
-| Surface | What it is |
-| --- | --- |
-| `/` (HTTP) | The MCP streamable HTTP endpoint. Browsers hitting this URL are redirected to `/portal/`; MCP clients pass through. |
-| `/portal/` | An embedded React 19 portal: dashboard, tools (with a per-tool Try-It form), audit log browser, API-key management, server config viewer, gateway-discovery surface. |
-| `/api/v1/portal/*` | Read-only REST endpoints behind cookie or API-key auth. Useful for scripting against a running server. |
-| `/api/v1/admin/*` | Mutating REST endpoints (key CRUD, Try-It proxy). |
-| `/.well-known/oauth-protected-resource` | RFC 9728 metadata advertising the issuer. The MCP auth gateway points 401 challenges at it. |
-| `/.well-known/oauth-authorization-server` | Stub pointing at the upstream issuer's metadata. |
-| `/healthz` and `/readyz` | Liveness and readiness probes. |
+<div class="def-cards" markdown>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">/</code></div>
+<div class="def-card__body" markdown>
+The MCP streamable HTTP endpoint. Browsers hitting this URL are redirected to `/portal/`; MCP clients pass through.
+</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">/portal/</code></div>
+<div class="def-card__body" markdown>
+An embedded React 19 portal: dashboard, tools (with a per-tool Try-It form), audit log browser, API-key management, server config viewer, gateway-discovery surface.
+</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">/api/v1/portal/*</code></div>
+<div class="def-card__body" markdown>
+Read-only REST endpoints behind cookie or API-key auth. Useful for scripting against a running server.
+</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">/api/v1/admin/*</code></div>
+<div class="def-card__body" markdown>
+Mutating REST endpoints (key CRUD, Try-It proxy).
+</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">/.well-known/oauth-protected-resource</code></div>
+<div class="def-card__body" markdown>
+RFC 9728 metadata advertising the issuer. The MCP auth gateway points 401 challenges at it.
+</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">/.well-known/oauth-authorization-server</code></div>
+<div class="def-card__body" markdown>
+Stub pointing at the upstream issuer's metadata.
+</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">/healthz and /readyz</code></div>
+<div class="def-card__body" markdown>
+Liveness and readiness probes.
+</div>
+</div>
+
+</div>
 
 ## Components in front of the binary
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -26,12 +26,29 @@ make dev
 
 When it's up:
 
-| URL | What |
-| --- | --- |
-| <http://localhost:8080/portal/> | Portal — sign in with `dev`/`dev` (OIDC) or paste an API key. |
-| <http://localhost:8080/> | MCP streamable HTTP endpoint. Browsers redirect to the portal; MCP clients pass through. |
-| <http://localhost:8081/> | Keycloak admin console (`admin`/`admin`). |
-| <http://localhost:8080/healthz> | Liveness. |
+<div class="def-cards" markdown>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">http://localhost:8080/portal/</code></div>
+<div class="def-card__body" markdown>Portal. Sign in with `dev` / `dev` (OIDC) or paste an API key.</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">http://localhost:8080/</code></div>
+<div class="def-card__body" markdown>MCP streamable HTTP endpoint. Browsers redirect to the portal; MCP clients pass through.</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">http://localhost:8081/</code></div>
+<div class="def-card__body" markdown>Keycloak admin console (`admin` / `admin`).</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">http://localhost:8080/healthz</code></div>
+<div class="def-card__body" markdown>Liveness.</div>
+</div>
+
+</div>
 
 The dev API key is `devkey-please-change`. Override it via
 `MCPTEST_DEV_KEY` if you want something else.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -32,8 +32,10 @@ mcp-test ships 12 tools across 4 categories. Each is a thin, deterministic shim 
 ## Operations
 
 - [Audit log](https://mcp-test.plexara.io/operations/audit/): Postgres schema, retention, redaction, and the JSON shape returned by the portal API.
+- [Inspection workflow](https://mcp-test.plexara.io/operations/inspection/): End-to-end operator walkthrough of the v1.2 audit drawer, comparison page, replay endpoint, JSONB filters, live tail, and NDJSON export.
 - [Portal](https://mcp-test.plexara.io/operations/portal/): React 19 SPA embedded into the binary; pages, Try-It proxy, dashboard.
 - [Deployment](https://mcp-test.plexara.io/operations/deployment/): Docker, Kubernetes, distroless image, healthcheck, graceful shutdown.
+- [Kubernetes example](https://mcp-test.plexara.io/operations/kubernetes/): Self-contained manifests + bash installer for an mcp-test + Postgres install on any cluster with nginx ingress and cert-manager. One file per resource, full YAML embedded inline.
 - [Testing a gateway](https://mcp-test.plexara.io/operations/gateway-testing/): Patterns for asserting on a gateway's identity-forwarding, redaction, enrichment, and progress-pass-through using mcp-test as the upstream.
 
 ## Reference

--- a/docs/operations/audit.md
+++ b/docs/operations/audit.md
@@ -21,21 +21,74 @@ Cascade delete on the foreign key keeps retention atomic: deleting an `audit_eve
 
 ## What gets recorded
 
-| Column | Source |
-| --- | --- |
-| `id` | UUID generated server-side. |
-| `ts` | UTC timestamp at the start of the call. |
-| `duration_ms` | End-to-end time the tool took, including the auth chain. |
-| `request_id` | UUID generated per call; useful for correlating across logs. |
-| `session_id` | The MCP session ID the SDK assigned at initialize. |
-| `user_subject` / `user_email` / `auth_type` / `api_key_name` | Resolved identity from the auth chain. |
-| `tool_name` / `tool_group` | Which tool, and which category. |
-| `parameters` | Sanitized arguments (JSONB). Keys matching `audit.redact_keys` have their values replaced with `"[redacted]"`. |
-| `success` / `error_message` / `error_category` | Outcome. `error_category` is a short label (`auth`, `tool`, `protocol`, etc.) for filtering. |
-| `request_chars` / `response_chars` / `content_blocks` | Sizing of input args and the result. Useful for spotting size-cap issues. |
-| `transport` | Always `"http"` today. |
-| `source` | `"mcp"` for real client calls, `"portal-tryit"` for portal-driven invocations. |
-| `remote_addr` / `user_agent` | From the inbound HTTP headers. |
+<div class="def-cards" markdown>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">id</code></div>
+<div class="def-card__body" markdown>UUID generated server-side.</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">ts</code></div>
+<div class="def-card__body" markdown>UTC timestamp at the start of the call.</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">duration_ms</code></div>
+<div class="def-card__body" markdown>End-to-end time the tool took, including the auth chain.</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">request_id</code></div>
+<div class="def-card__body" markdown>UUID generated per call; useful for correlating across logs.</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">session_id</code></div>
+<div class="def-card__body" markdown>The MCP session ID the SDK assigned at initialize.</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">user_subject / user_email / auth_type / api_key_name</code></div>
+<div class="def-card__body" markdown>Resolved identity from the auth chain.</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">tool_name / tool_group</code></div>
+<div class="def-card__body" markdown>Which tool, and which category.</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">parameters</code></div>
+<div class="def-card__body" markdown>Sanitized arguments (JSONB). Keys matching `audit.redact_keys` have their values replaced with `"[redacted]"`.</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">success / error_message / error_category</code></div>
+<div class="def-card__body" markdown>Outcome. `error_category` is a short label (`auth`, `tool`, `protocol`, etc.) for filtering.</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">request_chars / response_chars / content_blocks</code></div>
+<div class="def-card__body" markdown>Sizing of input args and the result. Useful for spotting size-cap issues.</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">transport</code></div>
+<div class="def-card__body" markdown>Always `"http"` today.</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">source</code></div>
+<div class="def-card__body" markdown>`"mcp"` for real client calls, `"portal-tryit"` for portal-driven invocations.</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">remote_addr / user_agent</code></div>
+<div class="def-card__body" markdown>From the inbound HTTP headers.</div>
+</div>
+
+</div>
 
 See [Database & Migrations](../configuration/database.md#schema) for
 the exact DDL and indexes.
@@ -56,14 +109,69 @@ p50 / p95 latency, unique users / tools, and a recent-activity table.
 
 ## REST endpoints
 
-| Endpoint | Returns |
-| --- | --- |
-| `GET /api/v1/portal/audit/events` | Paginated event list. Query params: `from`, `to` (RFC 3339), `tool`, `user`, `session`, `success` (`true`/`false`), `q` (free text), `limit`, `offset`. Plus the JSONB filters in the next section. |
-| `GET /api/v1/portal/audit/events/{id}` | Single event with captured payload (when present). |
-| `GET /api/v1/portal/audit/export` | NDJSON stream of summary rows. Same filter surface as `/events`. Capped at 100,000 rows per request. |
-| `GET /api/v1/portal/audit/timeseries` | Bucketed counts. Query params: `from`, `to`, `bucket` (Go duration like `1m`, `5m`). Returns `[{time, count, errors, avg_duration_ms}]`. |
-| `GET /api/v1/portal/audit/breakdown` | Group-by aggregations. Query param: `by` (one of `tool`, `user`, `success`, `auth_type`). Returns `[{key, count, errors}]`. |
-| `GET /api/v1/portal/dashboard` | The 1-hour summary. |
+<div class="api-endpoints" markdown>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/api/v1/portal/audit/events</code>
+</div>
+<div class="api-endpoint__body" markdown>
+Paginated event list. Query params: `from`, `to` (RFC 3339), `tool`, `user`, `session`, `success` (`true` / `false`), `q` (free text), `limit`, `offset`. Plus the JSONB filters in the next section.
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/api/v1/portal/audit/events/{id}</code>
+</div>
+<div class="api-endpoint__body" markdown>
+Single event with captured payload (when present).
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/api/v1/portal/audit/export</code>
+</div>
+<div class="api-endpoint__body" markdown>
+NDJSON stream of summary rows. Same filter surface as `/events`. Capped at 100,000 rows per request.
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/api/v1/portal/audit/timeseries</code>
+</div>
+<div class="api-endpoint__body" markdown>
+Bucketed counts. Query params: `from`, `to`, `bucket` (Go duration like `1m`, `5m`). Returns `[{time, count, errors, avg_duration_ms}]`.
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/api/v1/portal/audit/breakdown</code>
+</div>
+<div class="api-endpoint__body" markdown>
+Group-by aggregations. Query param: `by` (one of `tool`, `user`, `success`, `auth_type`). Returns `[{key, count, errors}]`.
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/api/v1/portal/dashboard</code>
+</div>
+<div class="api-endpoint__body" markdown>
+The 1-hour summary.
+</div>
+</div>
+
+</div>
 
 ### JSONB filters
 

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -51,6 +51,10 @@ Mount the config at `/app/configs/mcp-test.yaml` and run with
 
 ## Kubernetes
 
+For a self-contained, ready-to-run installation (manifests + bash installer with progress, Postgres bundled in-cluster), see [Kubernetes example](kubernetes.md). The notes below cover the building blocks if you're wiring mcp-test into existing cluster infrastructure.
+
+### Building blocks
+
 A minimal Deployment / Service / Ingress:
 
 ```yaml

--- a/docs/operations/gateway-testing.md
+++ b/docs/operations/gateway-testing.md
@@ -11,16 +11,14 @@ This page collects the patterns.
 
 ## The setup
 
-```
-┌────────┐      ┌─────────┐      ┌──────────┐
-│ client │ ──▶  │ gateway │ ──▶  │ mcp-test │
-└────────┘      └─────────┘      └──────────┘
-                                       │
-                                       ▼
-                                  ┌─────────┐
-                                  │ audit   │
-                                  │ (Postgres) │
-                                  └─────────┘
+```mermaid
+flowchart LR
+    client[client]
+    gateway[gateway]
+    mcptest[mcp-test]
+    audit[(audit<br/>Postgres)]
+
+    client --> gateway --> mcptest --> audit
 ```
 
 The client makes calls. The gateway transforms them (auth,
@@ -34,10 +32,16 @@ differ is what the gateway did.
 **Question:** does the gateway forward the original caller's identity,
 or does it re-authenticate and substitute its own?
 
-```
-client → gateway: Authorization: Bearer <user-jwt>
-                  │
-                  └─→ mcp-test: Authorization: Bearer <whichever>
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Client as client
+    participant Gateway as gateway
+    participant Server as mcp-test
+
+    Client->>Gateway: Authorization: Bearer <user-jwt>
+    Note right of Gateway: forward verbatim,<br/>or re-auth and substitute?
+    Gateway->>Server: Authorization: Bearer <whichever>
 ```
 
 Call `whoami`. The returned `subject` and `email` should match the

--- a/docs/operations/kubernetes.md
+++ b/docs/operations/kubernetes.md
@@ -1,0 +1,712 @@
+---
+title: Kubernetes example
+description: Self-contained Kubernetes manifests + install script for mcp-test and a single-replica Postgres. One file per resource, applied with progress.
+---
+
+# Kubernetes example
+
+A working installation of mcp-test on any Kubernetes cluster with an `nginx` ingress controller. One file per Kubernetes resource, applied with a small bash installer that prints `[N/M]` progress and waits on readiness between steps.
+
+The manifests live in [`examples/kubernetes/`](https://github.com/plexara/mcp-test/tree/main/examples/kubernetes) on the source repo. Clone the repo, edit the placeholders, run `./install.sh`.
+
+## What gets installed
+
+A single namespace with two workloads:
+
+```mermaid
+flowchart LR
+    client[client]
+    ingress["Ingress<br/>nginx + cert-manager"]
+    server["Deployment<br/>mcp-test"]
+    db[("StatefulSet<br/>postgres")]
+
+    client -->|"https://mcp-test-server.example.com/"| ingress
+    ingress --> server
+    server -->|"DATABASE_URL"| db
+```
+
+## Manifests
+
+The numeric file prefixes are the apply order; the installer (below) gates on Postgres readiness halfway through. Each file is small enough to read end-to-end. Replace the `REPLACE_ME_*` placeholders manually or let `install.sh` generate values for you on first run.
+
+### Namespace
+
+The namespace everything else lands in. Standard `app.kubernetes.io/*` labels for tooling discovery (Lens, k9s, ArgoCD).
+
+```yaml title="examples/kubernetes/00-namespace.yaml"
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mcp-test
+  labels:
+    app.kubernetes.io/name: mcp-test
+    app.kubernetes.io/part-of: mcp-test
+    app.kubernetes.io/managed-by: manifest
+```
+
+### Postgres Service
+
+Headless (`clusterIP: None`) so the StatefulSet gets a stable per-pod DNS record (`postgres-0.postgres.mcp-test.svc.cluster.local`). The mcp-test connection string uses the bare `postgres` host name; in-namespace DNS resolves it.
+
+```yaml title="examples/kubernetes/10-postgres-service.yaml"
+# Headless ClusterIP for the Postgres StatefulSet. mcp-test reaches the
+# DB via DNS name `postgres.mcp-test.svc.cluster.local:5432`. Headless
+# (clusterIP: None) gives the StatefulSet a stable per-pod DNS record
+# (`postgres-0.postgres...`); the connection string in 20-mcp-test-secret
+# uses the unqualified `postgres` host because both pods share a
+# namespace and DNS resolves it.
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: mcp-test
+  labels:
+    app: postgres
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/component: db
+    app.kubernetes.io/part-of: mcp-test
+spec:
+  clusterIP: None
+  selector:
+    app: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+      protocol: TCP
+```
+
+### Postgres Secret
+
+DB / user / password. The `POSTGRES_PASSWORD` placeholder is filled in-place by `install.sh` with `openssl rand -base64 24`. Pre-fill it manually if you want stable creds across reinstalls (a private fork pattern).
+
+```yaml title="examples/kubernetes/12-postgres-secret.yaml"
+# Postgres credentials. Used by both the postgres container (POSTGRES_*
+# env) and built into the mcp-test connection string in
+# 20-mcp-test-secret. The install.sh script will fill the empty fields
+# below with a random password on first run; pre-filling them here lets
+# you commit a fixed password to a private fork if you want stable creds
+# across reinstalls.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres
+  namespace: mcp-test
+  labels:
+    app: postgres
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/component: db
+    app.kubernetes.io/part-of: mcp-test
+type: Opaque
+stringData:
+  POSTGRES_DB: mcp_test
+  POSTGRES_USER: mcp
+  # REPLACE: 24+ char random string (e.g. `openssl rand -base64 24`).
+  # install.sh writes one for you on a fresh install.
+  POSTGRES_PASSWORD: "REPLACE_ME_POSTGRES_PASSWORD"
+```
+
+### Postgres StatefulSet
+
+Single replica with a 5Gi PVC. `pg_isready` probes for readiness and liveness. The `securityContext` runs as the `postgres` UID baked into the alpine image. Bump the storage request before scale-out demos.
+
+```yaml title="examples/kubernetes/14-postgres-statefulset.yaml"
+# Single-replica Postgres for the mcp-test audit log + DB-backed API
+# keys. 5Gi PVC sized for ~50M audit_events rows at the default
+# 30-day retention with payloads on. Bump the storage request before
+# scale-out demos.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: mcp-test
+  labels:
+    app: postgres
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/component: db
+    app.kubernetes.io/part-of: mcp-test
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+        app.kubernetes.io/name: postgres
+        app.kubernetes.io/component: db
+        app.kubernetes.io/part-of: mcp-test
+    spec:
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        runAsUser: 70 # postgres uid in the alpine image
+        runAsGroup: 70
+        fsGroup: 70
+      containers:
+        - name: postgres
+          image: postgres:17-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: postgres
+              containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: postgres
+                  key: POSTGRES_DB
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres
+                  key: POSTGRES_PASSWORD
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "mcp", "-d", "mcp_test"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "mcp", "-d", "mcp_test"]
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 5Gi
+        # storageClassName: REPLACE_ME (omit to use cluster default)
+```
+
+### mcp-test Secret
+
+Three application secrets: the full Postgres `DATABASE_URL` (built from the postgres password by the installer to keep them in sync), the portal cookie HMAC key, and the bootstrap `X-API-Key` value. All three are `REPLACE_ME` placeholders that `install.sh` fills with `openssl rand` output on first run.
+
+```yaml title="examples/kubernetes/20-mcp-test-secret.yaml"
+# Application secrets for mcp-test:
+#   - DATABASE_URL: full Postgres connection string. Built from the
+#     postgres credentials so this manifest is self-contained for
+#     installs that bundle Postgres in-cluster (the default). For an
+#     external Postgres, replace this with your own URL.
+#   - COOKIE_SECRET: HMAC key for the portal's session cookie. ANY
+#     32+ random bytes; rotating invalidates all live sessions.
+#   - DEV_KEY: bootstrap API key. Sent as `X-API-Key: <value>` to MCP
+#     and admin endpoints; matches the `api_keys.file` entry in the
+#     ConfigMap.
+#
+# install.sh fills the empty fields below with `openssl rand` output
+# on a fresh install. The DATABASE_URL also references the postgres
+# password; the script regenerates the URL whenever it touches the
+# postgres secret to keep them in sync.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mcp-test
+  namespace: mcp-test
+  labels:
+    app: mcp-test
+    app.kubernetes.io/name: mcp-test
+    app.kubernetes.io/component: server
+    app.kubernetes.io/part-of: mcp-test
+type: Opaque
+stringData:
+  # postgres://USER:PASSWORD@HOST:5432/DB?sslmode=disable
+  DATABASE_URL: "REPLACE_ME_DATABASE_URL"
+  # 32 bytes base64 (e.g. `openssl rand -base64 32`)
+  COOKIE_SECRET: "REPLACE_ME_COOKIE_SECRET"
+  # API key sent as `X-API-Key`. Use a long random value or the
+  # mcptest_-prefixed format the dev tooling produces.
+  DEV_KEY: "REPLACE_ME_DEV_API_KEY"
+```
+
+### mcp-test ConfigMap
+
+The full `mcp-test.yaml` runtime config. Defaults: API-key auth (OIDC commented out), audit on with payloads + headers + 30-day retention, all four toolkits enabled. The container reads `${MCPTEST_DATABASE_URL}`, `${MCPTEST_COOKIE_SECRET}`, and `${MCPTEST_DEV_KEY}` via env interpolation; those env vars come from the Secret above.
+
+REPLACE: `server.base_url` if your ingress host isn't `mcp-test-server.example.com`.
+
+```yaml title="examples/kubernetes/25-mcp-test-configmap.yaml"
+# mcp-test runtime config. The container reads this from
+# /etc/mcp-test/mcp-test.yaml; see 40-mcp-test-deployment.yaml.
+#
+# Defaults below ship a working installation with:
+#   - API-key auth only (OIDC disabled). Operators authenticate by
+#     pasting the dev key on the portal login screen, and MCP clients
+#     send `X-API-Key: <DEV_KEY>`. To turn on OIDC instead, set
+#     `oidc.enabled: true` and supply issuer + client credentials via
+#     additional secret keys + env mappings in the Deployment.
+#   - Audit log fully on, payloads + headers captured, 30-day retention.
+#   - Portal at /portal/, MCP at /, behind the same Ingress.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcp-test
+  namespace: mcp-test
+  labels:
+    app: mcp-test
+    app.kubernetes.io/name: mcp-test
+    app.kubernetes.io/component: server
+    app.kubernetes.io/part-of: mcp-test
+data:
+  mcp-test.yaml: |
+    server:
+      name: mcp-test
+      address: ":8080"
+      # REPLACE: must match the public URL clients reach this server at.
+      # Used in OIDC redirects (when enabled) and RFC 9728 metadata.
+      base_url: "https://mcp-test-server.example.com"
+      read_header_timeout: 10s
+      shutdown:
+        grace_period: 25s
+        pre_shutdown_delay: 2s
+      tls:
+        enabled: false
+      streamable:
+        session_timeout: 30m
+        stateless: false
+        json_response: false
+
+    oidc:
+      enabled: false
+      # When you flip enabled to true, supply these via env from a
+      # secret you add yourself. The defaults below match the dev
+      # Keycloak; replace with your real issuer.
+      # issuer: "https://your-idp.example.com/realms/mcp-test"
+      # audience: "mcp-test"
+      # client_id: "${MCPTEST_OIDC_CLIENT_ID}"
+      # client_secret: "${MCPTEST_OIDC_CLIENT_SECRET}"
+
+    api_keys:
+      file:
+        - name: bootstrap
+          key: "${MCPTEST_DEV_KEY}"
+          description: "Bootstrap API key for portal admin and MCP smoke tests"
+      db:
+        enabled: true
+
+    auth:
+      allow_anonymous: false
+      require_for_mcp: true
+      require_for_portal: true
+
+    database:
+      url: "${MCPTEST_DATABASE_URL}"
+      max_open_conns: 25
+      max_idle_conns: 5
+      conn_max_lifetime: 1h
+
+    audit:
+      enabled: true
+      capture_payloads: true
+      capture_headers: true
+      max_payload_bytes: 65536
+      retention_days: 30
+      redact_keys: [password, token, secret, authorization, api_key, credentials, cookie]
+
+    portal:
+      enabled: true
+      cookie_name: mcp_test_session
+      cookie_secret: "${MCPTEST_COOKIE_SECRET}"
+      # cookie_secure must be false when serving over plain HTTP locally;
+      # leave true for the Ingress + cert-manager flow this example uses.
+      cookie_secure: true
+      oidc_redirect_path: /portal/auth/callback
+
+    tools:
+      identity:  { enabled: true }
+      data:      { enabled: true }
+      failure:   { enabled: true }
+      streaming: { enabled: true }
+```
+
+### mcp-test Service
+
+ClusterIP, port 8080. The Ingress points at this Service.
+
+```yaml title="examples/kubernetes/30-mcp-test-service.yaml"
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-test
+  namespace: mcp-test
+  labels:
+    app: mcp-test
+    app.kubernetes.io/name: mcp-test
+    app.kubernetes.io/component: server
+    app.kubernetes.io/part-of: mcp-test
+spec:
+  type: ClusterIP
+  selector:
+    app: mcp-test
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: http
+```
+
+### mcp-test Deployment
+
+Single replica (mcp-test is stateless once Postgres is reachable; bump for HA). Reads its config from `/etc/mcp-test/mcp-test.yaml` via the mounted ConfigMap; reads three env vars from the Secret. Tight `securityContext` (non-root, read-only root FS, all capabilities dropped). The `config-hash` / `secret-hash` annotations are placeholders that `install.sh` patches to a SHA256 of the on-disk file contents so a config change triggers a rollout automatically.
+
+```yaml title="examples/kubernetes/40-mcp-test-deployment.yaml"
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-test
+  namespace: mcp-test
+  labels:
+    app: mcp-test
+    app.kubernetes.io/name: mcp-test
+    app.kubernetes.io/component: server
+    app.kubernetes.io/part-of: mcp-test
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app: mcp-test
+  template:
+    metadata:
+      labels:
+        app: mcp-test
+        app.kubernetes.io/name: mcp-test
+        app.kubernetes.io/component: server
+        app.kubernetes.io/part-of: mcp-test
+      annotations:
+        # Force a rollout when ConfigMap or Secret content changes.
+        # install.sh patches these to a SHA256 of the on-disk file
+        # contents; replace manually with `kubectl rollout restart` if
+        # you edit the manifests outside the script.
+        config-hash: "0"
+        secret-hash: "0"
+    spec:
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: mcp-test
+          image: ghcr.io/plexara/mcp-test:v1.2.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config
+            - /etc/mcp-test/mcp-test.yaml
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: MCPTEST_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: mcp-test
+                  key: DATABASE_URL
+            - name: MCPTEST_COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: mcp-test
+                  key: COOKIE_SECRET
+            - name: MCPTEST_DEV_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mcp-test
+                  key: DEV_KEY
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mcp-test
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      volumes:
+        - name: config
+          configMap:
+            name: mcp-test
+```
+
+### mcp-test Ingress
+
+cert-manager automation for TLS, CORS for browser-side MCP gateways, and the long-timeout / no-buffer nginx annotations the streamable HTTP transport needs (live tail and SSE responses can't tolerate proxy buffering).
+
+REPLACE: `mcp-test-server.example.com` (3 occurrences) with your DNS name. `install.sh` rewrites them in-place when you set `INGRESS_HOST`.
+
+```yaml title="examples/kubernetes/50-mcp-test-ingress.yaml"
+# Ingress for mcp-test. Assumes:
+#   - ingress-nginx as the controller (annotations are nginx-specific).
+#     Adjust for traefik / aws-load-balancer-controller / etc.
+#   - cert-manager with a `letsencrypt-production` ClusterIssuer for
+#     automated TLS. Remove the `cert-manager.io/cluster-issuer`
+#     annotation and the `tls:` block if you handle TLS at a different
+#     layer (terminating LB, service mesh, etc.).
+#
+# REPLACE: `mcp-test-server.example.com` (3 occurrences below) with the
+# DNS name your Ingress controller routes to this service.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mcp-test
+  namespace: mcp-test
+  labels:
+    app: mcp-test
+    app.kubernetes.io/name: mcp-test
+    app.kubernetes.io/component: server
+    app.kubernetes.io/part-of: mcp-test
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    # CORS: lets a browser-side MCP gateway call this server. Tighten
+    # the allow-origin list to the gateway hosts you actually use.
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, DELETE, OPTIONS"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "*"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+    # Streamable HTTP / SSE: long-lived connections for live tail and
+    # MCP server-initiated messages. Disable buffering so the client
+    # sees frames as they're written.
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-buffering: "off"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
+    nginx.ingress.kubernetes.io/service-upstream: "true"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: mcp-test-server.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mcp-test
+                port:
+                  number: 8080
+  tls:
+    - hosts:
+        - mcp-test-server.example.com
+      secretName: mcp-test-tls
+```
+
+## Install
+
+```sh
+git clone https://github.com/plexara/mcp-test.git
+cd mcp-test/examples/kubernetes
+
+INGRESS_HOST=mcp.example.com ./install.sh
+```
+
+The full source of [`install.sh`](https://github.com/plexara/mcp-test/blob/main/examples/kubernetes/install.sh) is in the repo. The two interesting blocks are the placeholder-fill (generates secrets in-place) and the apply loop (gates on Postgres readiness):
+
+```bash title="examples/kubernetes/install.sh (excerpt: placeholder fill)"
+# Postgres password
+if grep -q 'REPLACE_ME_POSTGRES_PASSWORD' "$PG_SECRET"; then
+  pgpw="$(openssl rand -base64 24 | tr -d '\n=+/' | head -c 28)"
+  sed -i.bak "s|REPLACE_ME_POSTGRES_PASSWORD|${pgpw}|" "$PG_SECRET" && rm -f "$PG_SECRET.bak"
+fi
+
+# Application secrets
+if grep -q 'REPLACE_ME_COOKIE_SECRET' "$APP_SECRET"; then
+  cookie="$(openssl rand -base64 32 | tr -d '\n')"
+  sed -i.bak "s|REPLACE_ME_COOKIE_SECRET|${cookie}|" "$APP_SECRET" && rm -f "$APP_SECRET.bak"
+fi
+if grep -q 'REPLACE_ME_DEV_API_KEY' "$APP_SECRET"; then
+  devkey="mcptest_$(openssl rand -base64 24 | tr -d '\n=+/' | head -c 32)"
+  sed -i.bak "s|REPLACE_ME_DEV_API_KEY|${devkey}|" "$APP_SECRET" && rm -f "$APP_SECRET.bak"
+fi
+if grep -q 'REPLACE_ME_DATABASE_URL' "$APP_SECRET"; then
+  dburl="postgres://mcp:${pgpw}@postgres:5432/mcp_test?sslmode=disable"
+  sed -i.bak "s|REPLACE_ME_DATABASE_URL|${dburl}|" "$APP_SECRET" && rm -f "$APP_SECRET.bak"
+fi
+```
+
+```bash title="examples/kubernetes/install.sh (excerpt: apply loop with readiness gates)"
+for f in "${MANIFESTS[@]}"; do
+  case "$f" in
+    14-postgres-statefulset.yaml)
+      step "$i" "applying $f"
+      apply "$SCRIPT_DIR/$f"
+      step "$i" "waiting for Postgres pod ready..."
+      kubectl -n "$NAMESPACE" wait --for=condition=Ready pod/postgres-0 \
+          --timeout=180s
+      ;;
+    40-mcp-test-deployment.yaml)
+      step "$i" "applying $f (config-hash=${config_hash}, secret-hash=${secret_hash})"
+      sed -e "s|config-hash: \"0\"|config-hash: \"${config_hash}\"|" \
+          -e "s|secret-hash: \"0\"|secret-hash: \"${secret_hash}\"|" \
+          "$SCRIPT_DIR/$f" | kubectl apply -f -
+      step "$i" "waiting for mcp-test rollout..."
+      kubectl -n "$NAMESPACE" rollout status deploy/mcp-test --timeout=180s
+      ;;
+    *)
+      step "$i" "applying $f"
+      apply "$SCRIPT_DIR/$f"
+      ;;
+  esac
+done
+```
+
+The installer:
+
+1. Confirms the current `kubectl` context interactively before applying.
+2. Generates the postgres password, portal cookie secret, and dev API key in-place where the manifests still hold `REPLACE_ME` placeholders.
+3. Rewrites `mcp-test-server.example.com` to `$INGRESS_HOST` in `50-mcp-test-ingress.yaml`.
+4. Applies manifests in numeric order with `[N/M]` progress.
+5. Waits for `pod/postgres-0` to be `Ready` (180s) before applying the mcp-test side.
+6. Waits for the mcp-test Deployment rollout (180s).
+7. Patches a `config-hash` / `secret-hash` annotation on the Deployment so a re-run after a config edit triggers a new rollout without `kubectl rollout restart`.
+8. Prints the URLs and the dev API key.
+
+Variables it honors:
+
+<div class="config-keys" markdown>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">INGRESS_HOST</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">default</span><span class="config-key__chip-value">prompts</span></span>
+<span class="config-key__chip"><span class="config-key__chip-label">example</span><code class="config-key__chip-value">mcp.example.com</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+DNS name your ingress controller routes to mcp-test. Rewrites `50-mcp-test-ingress.yaml` in place. Also update `server.base_url` in `25-mcp-test-configmap.yaml` to match.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">KUBE_CONTEXT</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">default</span><span class="config-key__chip-value">current</span></span>
+<span class="config-key__chip"><span class="config-key__chip-label">example</span><code class="config-key__chip-value">staging</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+kubectl context to install into. The installer confirms it interactively before applying.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">--dry-run</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">flag</span><span class="config-key__chip-value">off</span></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Renders manifests, doesn't apply. Useful for previewing the placeholders the installer would fill.
+</div>
+</div>
+
+</div>
+
+## Smoke test
+
+Once the install finishes:
+
+```sh
+HOST="https://${INGRESS_HOST}"
+KEY="<value printed by install.sh>"
+
+# Liveness
+curl -i "${HOST}/healthz"
+
+# Identity through the portal API
+curl -i -H "X-API-Key: ${KEY}" "${HOST}/api/v1/portal/me"
+
+# Initialize an MCP session, then call a tool.
+curl -i -X POST "${HOST}/" \
+  -H "X-API-Key: ${KEY}" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","clientInfo":{"name":"smoketest","version":"0.1"},"capabilities":{}}}'
+```
+
+Then open `https://${INGRESS_HOST}/portal/` and paste the same `X-API-Key` value into the login screen.
+
+## Variations
+
+### External Postgres
+
+Drop `10-postgres-service.yaml`, `12-postgres-secret.yaml`, and `14-postgres-statefulset.yaml`. Replace the `DATABASE_URL` field in `20-mcp-test-secret.yaml` with your own connection string. If you use `sslmode=verify-full`, make sure the mcp-test pod trusts your CA chain (volume-mount it into `/etc/ssl/certs/` and set `SSL_CERT_DIR`).
+
+### OIDC instead of API keys
+
+In `25-mcp-test-configmap.yaml`, set `oidc.enabled: true` and fill `oidc.issuer` / `oidc.audience`. Add an `MCPTEST_OIDC_CLIENT_ID` / `MCPTEST_OIDC_CLIENT_SECRET` env mapping in `40-mcp-test-deployment.yaml` from a secret you create. The full identity model is documented in [Authentication](../configuration/auth.md).
+
+### Different ingress controller
+
+The annotations in `50-mcp-test-ingress.yaml` are nginx-specific. For traefik, aws-load-balancer-controller, or GKE ingress, swap them for the equivalent timeout / CORS / buffer-disable annotations and update `ingressClassName` to match.
+
+### Plain HTTP for local clusters
+
+Drop the `tls:` block in `50-mcp-test-ingress.yaml` and set `portal.cookie_secure: false` in the ConfigMap. Cookies won't survive a session over plain HTTP otherwise.
+
+### Higher replicas
+
+mcp-test is stateless once Postgres is reachable. Bump `replicas` on the Deployment; the StatefulSet stays at 1. The audit log uses Postgres advisory locks for the serial migration step on startup, so concurrent rollouts converge correctly.
+
+## Uninstall
+
+```sh
+kubectl delete namespace mcp-test
+```
+
+The PVC bound by the Postgres StatefulSet is in the namespace and goes with it. Preserve audit data across reinstalls by adding a finalizer to the PVC before deleting the namespace, or by switching to an external Postgres.

--- a/docs/operations/portal.md
+++ b/docs/operations/portal.md
@@ -10,18 +10,59 @@ binary via `go:embed all:dist`. There's no separate frontend server.
 
 ## Routes
 
-| Route | What |
-| --- | --- |
-| `/portal/login` | Sign in with OIDC or paste an API key. |
-| `/portal/` | Dashboard: 1-hour stats and recent activity. |
-| `/portal/tools` | Tool catalog grouped by category. |
-| `/portal/tools/<name>` | Per-tool detail with Overview / Try It tabs. |
-| `/portal/audit` | Filterable event browser with pagination, click-to-expand drawer, JSONB filters, SSE live tail. |
-| `/portal/audit/compare` | Side-by-side structural diff of two events; staged from the drawer's Compare button (`?a=<id>&b=<id>`). |
-| `/portal/keys` | DB-backed API key management. |
-| `/portal/config` | Read-only JSON view of the running config (secrets redacted). |
-| `/portal/wellknown` | Pretty-print of the protected-resource and authorization-server metadata that gateways read. |
-| `/portal/about` | Description of the server, the categories, and the live `server.instructions`. |
+<div class="def-cards" markdown>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">/portal/login</code></div>
+<div class="def-card__body" markdown>Sign in with OIDC or paste an API key.</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">/portal/</code></div>
+<div class="def-card__body" markdown>Dashboard: 1-hour stats and recent activity.</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">/portal/tools</code></div>
+<div class="def-card__body" markdown>Tool catalog grouped by category.</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">/portal/tools/&lt;name&gt;</code></div>
+<div class="def-card__body" markdown>Per-tool detail with Overview / Try It tabs.</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">/portal/audit</code></div>
+<div class="def-card__body" markdown>Filterable event browser with pagination, click-to-expand drawer, JSONB filters, SSE live tail.</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">/portal/audit/compare</code></div>
+<div class="def-card__body" markdown>Side-by-side structural diff of two events; staged from the drawer's Compare button (`?a=<id>&b=<id>`).</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">/portal/keys</code></div>
+<div class="def-card__body" markdown>DB-backed API key management.</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">/portal/config</code></div>
+<div class="def-card__body" markdown>Read-only JSON view of the running config (secrets redacted).</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">/portal/wellknown</code></div>
+<div class="def-card__body" markdown>Pretty-print of the protected-resource and authorization-server metadata that gateways read.</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">/portal/about</code></div>
+<div class="def-card__body" markdown>Description of the server, the categories, and the live `server.instructions`.</div>
+</div>
+
+</div>
 
 ## Authentication
 

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -11,16 +11,89 @@ Every HTTP route mcp-test exposes, beyond the MCP transport itself.
 
 These are reachable without auth.
 
-| Method | Path | Returns |
-| --- | --- | --- |
-| `GET` | `/healthz` | `200 OK` text body. Liveness. |
-| `GET` | `/readyz` | `200 OK` while ready, `503` during shutdown drain. |
-| `GET` | `/.well-known/oauth-protected-resource` | RFC 9728 metadata: resource identifier, authorization servers, supported bearer methods. |
-| `GET` | `/.well-known/oauth-authorization-server` | Lightweight stub pointing at the upstream OIDC issuer's metadata URL. |
-| `GET` | `/portal/` and subpaths | The embedded React SPA (or a placeholder if `make ui` wasn't run). |
-| `GET` | `/portal/auth/login` | Starts the OIDC PKCE flow. Redirects to the IdP. |
-| `GET` | `/portal/auth/callback` | OIDC redirect URI. Exchanges the auth code for tokens, validates the id_token, sets the session cookie. |
-| `POST` | `/portal/auth/logout` | Clears the session cookie. |
+<div class="api-endpoints" markdown>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/healthz</code>
+</div>
+<div class="api-endpoint__body" markdown>
+`200 OK` text body. Liveness.
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/readyz</code>
+</div>
+<div class="api-endpoint__body" markdown>
+`200 OK` while ready, `503` during shutdown drain.
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/.well-known/oauth-protected-resource</code>
+</div>
+<div class="api-endpoint__body" markdown>
+RFC 9728 metadata: resource identifier, authorization servers, supported bearer methods.
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/.well-known/oauth-authorization-server</code>
+</div>
+<div class="api-endpoint__body" markdown>
+Lightweight stub pointing at the upstream OIDC issuer's metadata URL.
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/portal/</code>
+</div>
+<div class="api-endpoint__body" markdown>
+The embedded React SPA (or a placeholder if `make ui` wasn't run). Subpaths route to the SPA's client-side router.
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/portal/auth/login</code>
+</div>
+<div class="api-endpoint__body" markdown>
+Starts the OIDC PKCE flow. Redirects to the IdP.
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/portal/auth/callback</code>
+</div>
+<div class="api-endpoint__body" markdown>
+OIDC redirect URI. Exchanges the auth code for tokens, validates the id_token, sets the session cookie.
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--post" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--post">POST</span>
+<code class="api-endpoint__path">/portal/auth/logout</code>
+</div>
+<div class="api-endpoint__body" markdown>
+Clears the session cookie.
+</div>
+</div>
+
+</div>
 
 ## MCP endpoint
 
@@ -28,11 +101,39 @@ Mounted at `/`. Browser GETs hitting `/` get a 302 to `/portal/`; MCP
 clients (which send `Accept: application/json` or
 `text/event-stream`) pass through.
 
-| Method | Path | Returns |
-| --- | --- | --- |
-| `POST` | `/` | JSON-RPC requests (initialize, tools/list, tools/call, etc.). |
-| `GET` | `/` | SSE stream for server-initiated messages (after a session is established). |
-| `DELETE` | `/` | Tear down the MCP session. |
+<div class="api-endpoints" markdown>
+
+<div class="api-endpoint api-endpoint--post" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--post">POST</span>
+<code class="api-endpoint__path">/</code>
+</div>
+<div class="api-endpoint__body" markdown>
+JSON-RPC requests (`initialize`, `tools/list`, `tools/call`, etc.).
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/</code>
+</div>
+<div class="api-endpoint__body" markdown>
+SSE stream for server-initiated messages (after a session is established).
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--delete" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--delete">DELETE</span>
+<code class="api-endpoint__path">/</code>
+</div>
+<div class="api-endpoint__body" markdown>
+Tear down the MCP session.
+</div>
+</div>
+
+</div>
 
 All require `X-API-Key` or `Authorization: Bearer <jwt>` unless
 `auth.allow_anonymous` is true. 401s carry a `WWW-Authenticate: Bearer
@@ -42,34 +143,203 @@ realm="mcp-test", resource_metadata="..."` header.
 
 Behind the cookie or `X-API-Key` / `Authorization: Bearer`.
 
-| Method | Path | Returns |
-| --- | --- | --- |
-| `GET` | `/api/v1/portal/me` | Resolved Identity object. |
-| `GET` | `/api/v1/portal/server` | Build version + sanitized config (secrets redacted). |
-| `GET` | `/api/v1/portal/instructions` | The `server.instructions` text the MCP server hands to clients at initialize time. |
-| `GET` | `/api/v1/portal/tools` | List of `{name, group, description, input_schema}` for every registered tool. |
-| `GET` | `/api/v1/portal/tools/{name}` | Same shape, single tool. |
-| `GET` | `/api/v1/portal/audit/meta` | Filter contract surface: `{has_keys, json_sources, replay: {burst, refill_secs, sustained_min}, export: {max_rows}}`. Lets a UI build its filter editor against the server's source of truth without duplicating allow-lists. |
-| `GET` | `/api/v1/portal/audit/events` | Paginated audit events. Query: `from`, `to` (RFC 3339), `tool`, `user`, `session`, `success`, `q`, `limit`, `offset`, plus the JSONB filters described below. |
-| `GET` | `/api/v1/portal/audit/events/{id}` | Single event by id (UUID); includes the captured payload row when present. 400 on a non-UUID id, 404 when the event isn't recorded. |
-| `POST` | `/api/v1/portal/audit/events/{id}/replay` | Re-invokes the captured tool call through an in-process MCP client. Writes a new audit event tagged `source=portal-replay` with `replayed_from` pointing at `{id}`. Per-identity rate limited (5 burst, 1 token / 12s); returns `429 Too Many Requests` with `Retry-After` when exhausted. Tokens are consumed *after* validation passes, so a click on a non-replayable row (no payload, redacted params, missing tool) returns `400` without burning the operator's budget. CSRF-gated via `X-Requested-With`. |
-| `GET` | `/api/v1/portal/audit/export` | NDJSON stream of summary rows for a filter. `format=jsonl` (default) is the only supported format. Same filter surface as `/events`. Capped at 100,000 rows per request. |
-| `GET` | `/api/v1/portal/audit/stream` | SSE live tail of new audit events. One `event: audit\ndata: <event JSON>` per write; opening comment `: connected` confirms the connection; `: keepalive` every 30 seconds. Sets `X-Accel-Buffering: no` for nginx-fronted deployments. |
-| `GET` | `/api/v1/portal/audit/timeseries` | Bucketed counts. Query: `from`, `to`, `bucket` (Go duration). |
-| `GET` | `/api/v1/portal/audit/breakdown` | Group-by aggregations. Query: `by` (`tool`/`user`/`success`/`auth_type`). |
-| `GET` | `/api/v1/portal/dashboard` | 1-hour stats + recent activity. |
-| `GET` | `/api/v1/portal/wellknown` | Pretty rendering of the protected-resource metadata. |
+<div class="api-endpoints" markdown>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/api/v1/portal/me</code>
+</div>
+<div class="api-endpoint__body" markdown>
+Resolved Identity object.
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/api/v1/portal/server</code>
+</div>
+<div class="api-endpoint__body" markdown>
+Build version + sanitized config (secrets redacted).
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/api/v1/portal/instructions</code>
+</div>
+<div class="api-endpoint__body" markdown>
+The `server.instructions` text the MCP server hands to clients at initialize time.
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/api/v1/portal/tools</code>
+</div>
+<div class="api-endpoint__body" markdown>
+List of `{name, group, description, input_schema}` for every registered tool.
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/api/v1/portal/tools/{name}</code>
+</div>
+<div class="api-endpoint__body" markdown>
+Same shape, single tool.
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/api/v1/portal/audit/meta</code>
+</div>
+<div class="api-endpoint__body" markdown>
+Filter contract surface: `{has_keys, json_sources, replay: {burst, refill_secs, sustained_min}, export: {max_rows}}`. Lets a UI build its filter editor against the server's source of truth without duplicating allow-lists.
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/api/v1/portal/audit/events</code>
+</div>
+<div class="api-endpoint__body" markdown>
+Paginated audit events. Query: `from`, `to` (RFC 3339), `tool`, `user`, `session`, `success`, `q`, `limit`, `offset`, plus the JSONB filters described below.
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/api/v1/portal/audit/events/{id}</code>
+</div>
+<div class="api-endpoint__body" markdown>
+Single event by id (UUID); includes the captured payload row when present. `400` on a non-UUID id, `404` when the event isn't recorded.
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--post" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--post">POST</span>
+<code class="api-endpoint__path">/api/v1/portal/audit/events/{id}/replay</code>
+</div>
+<div class="api-endpoint__body" markdown>
+Re-invokes the captured tool call through an in-process MCP client. Writes a new audit event tagged `source=portal-replay` with `replayed_from` pointing at `{id}`. Per-identity rate limited (5 burst, 1 token / 12s); returns `429 Too Many Requests` with `Retry-After` when exhausted. Tokens are consumed *after* validation passes, so a click on a non-replayable row (no payload, redacted params, missing tool) returns `400` without burning the operator's budget. CSRF-gated via `X-Requested-With`.
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/api/v1/portal/audit/export</code>
+</div>
+<div class="api-endpoint__body" markdown>
+NDJSON stream of summary rows for a filter. `format=jsonl` (default) is the only supported format. Same filter surface as `/events`. Capped at 100,000 rows per request.
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/api/v1/portal/audit/stream</code>
+</div>
+<div class="api-endpoint__body" markdown>
+SSE live tail of new audit events. One `event: audit\ndata: <event JSON>` per write; opening comment `: connected` confirms the connection; `: keepalive` every 30 seconds. Sets `X-Accel-Buffering: no` for nginx-fronted deployments.
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/api/v1/portal/audit/timeseries</code>
+</div>
+<div class="api-endpoint__body" markdown>
+Bucketed counts. Query: `from`, `to`, `bucket` (Go duration).
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/api/v1/portal/audit/breakdown</code>
+</div>
+<div class="api-endpoint__body" markdown>
+Group-by aggregations. Query: `by` (`tool` / `user` / `success` / `auth_type`).
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/api/v1/portal/dashboard</code>
+</div>
+<div class="api-endpoint__body" markdown>
+1-hour stats + recent activity.
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/api/v1/portal/wellknown</code>
+</div>
+<div class="api-endpoint__body" markdown>
+Pretty rendering of the protected-resource metadata.
+</div>
+</div>
+
+</div>
 
 ### JSONB path filters
 
 `/audit/events` and `/audit/export` accept additional query parameters that compile to JSONB containment predicates against the `audit_payloads` sibling row. Filters are AND-combined with each other and with the indexed-column filters above.
 
-| Syntax | Compiles to | Example |
-| --- | --- | --- |
-| `param.<dotted.path>=<value>` | `audit_payloads.request_params @> {"<path>": <value>}` | `?param.user.id=alice` |
-| `response.<dotted.path>=<value>` | `audit_payloads.response_result @> {"<path>": <value>}` | `?response.isError=true` |
-| `header.<name>=<value>` | `audit_payloads.request_headers @> {"<name>": ["<value>"]}` (single-segment name only) | `?header.User-Agent=curl/8.0` |
-| `has=<column>` | `audit_payloads.<column>` is `IS NOT NULL` and the column's text representation is not one of `'{}'`, `'[]'`, `'null'`, or `''` | `?has=response_error` |
+<div class="def-cards" markdown>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">param.&lt;dotted.path&gt;=&lt;value&gt;</code></div>
+<div class="def-card__body" markdown>
+Compiles to `audit_payloads.request_params @> {"<path>": <value>}`.
+
+Example: `?param.user.id=alice`
+</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">response.&lt;dotted.path&gt;=&lt;value&gt;</code></div>
+<div class="def-card__body" markdown>
+Compiles to `audit_payloads.response_result @> {"<path>": <value>}`.
+
+Example: `?response.isError=true`
+</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">header.&lt;name&gt;=&lt;value&gt;</code></div>
+<div class="def-card__body" markdown>
+Compiles to `audit_payloads.request_headers @> {"<name>": ["<value>"]}` (single-segment name only).
+
+Example: `?header.User-Agent=curl/8.0`
+</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">has=&lt;column&gt;</code></div>
+<div class="def-card__body" markdown>
+`audit_payloads.<column>` is `IS NOT NULL` and the column's text representation is not one of `'{}'`, `'[]'`, `'null'`, or `''`.
+
+Example: `?has=response_error`
+</div>
+</div>
+
+</div>
 
 Allowed `has=` columns: `request_params`, `request_headers`, `response_result`, `response_error`, `notifications`, `replayed_from`. Anything else is silently dropped. Note: a JSONB column literally storing the JSON string `""` (rendered as `'""'::text`, four characters) does pass the filter; the exclusion list is canonical empty containers and an empty TEXT column, not "all logically empty values."
 
@@ -88,12 +358,63 @@ Allowed `has=` columns: `request_params`, `request_headers`, `response_result`, 
 Same auth requirements. Per the project decision, any authenticated
 caller can call these.
 
-| Method | Path | Body | Returns |
-| --- | --- | --- | --- |
-| `POST` | `/api/v1/admin/keys` | `{ "name": "...", "description": "..." }` | `{ "key": {...}, "plaintext": "mt_..." }` (plaintext shown once). |
-| `GET` | `/api/v1/admin/keys` | — | `{ "keys": [...] }` (no plaintext). |
-| `DELETE` | `/api/v1/admin/keys/{name}` | — | `204 No Content`. |
-| `POST` | `/api/v1/admin/tryit/{name}` | `{ "arguments": { ... } }` | The MCP `CallToolResult` (content + structuredContent + isError). |
+<div class="api-endpoints" markdown>
+
+<div class="api-endpoint api-endpoint--post" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--post">POST</span>
+<code class="api-endpoint__path">/api/v1/admin/keys</code>
+</div>
+<div class="api-endpoint__body" markdown>
+Mint a new DB-backed API key.
+<dl class="api-endpoint__meta">
+<dt>Body</dt><dd><code>{ "name": "...", "description": "..." }</code></dd>
+<dt>Returns</dt><dd><code>{ "key": {...}, "plaintext": "mt_..." }</code> (plaintext shown once).</dd>
+</dl>
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--get" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--get">GET</span>
+<code class="api-endpoint__path">/api/v1/admin/keys</code>
+</div>
+<div class="api-endpoint__body" markdown>
+List all DB-backed API keys.
+<dl class="api-endpoint__meta">
+<dt>Returns</dt><dd><code>{ "keys": [...] }</code> (no plaintext).</dd>
+</dl>
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--delete" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--delete">DELETE</span>
+<code class="api-endpoint__path">/api/v1/admin/keys/{name}</code>
+</div>
+<div class="api-endpoint__body" markdown>
+Revoke a DB-backed API key by name.
+<dl class="api-endpoint__meta">
+<dt>Returns</dt><dd><code>204 No Content</code>.</dd>
+</dl>
+</div>
+</div>
+
+<div class="api-endpoint api-endpoint--post" markdown>
+<div class="api-endpoint__head">
+<span class="api-endpoint__method api-endpoint__method--post">POST</span>
+<code class="api-endpoint__path">/api/v1/admin/tryit/{name}</code>
+</div>
+<div class="api-endpoint__body" markdown>
+Invoke a registered tool through the in-process MCP client; the call lands in the audit log tagged `source=portal-tryit`.
+<dl class="api-endpoint__meta">
+<dt>Body</dt><dd><code>{ "arguments": { ... } }</code></dd>
+<dt>Returns</dt><dd>The MCP <code>CallToolResult</code> (content + structuredContent + isError).</dd>
+</dl>
+</div>
+</div>
+
+</div>
 
 `/api/v1/admin/tryit/{name}` invokes the named tool through an
 in-process MCP client connected to the running server. It writes its

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -43,13 +43,40 @@ implemented; they're not relevant to a gateway test fixture.)
 The SDK handles every standard MCP method. The relevant ones for
 mcp-test:
 
-| Method | Notes |
-| --- | --- |
-| `initialize` | Returns `serverInfo` (name, version), `capabilities`, `protocolVersion`, and `instructions` (see [Server Instructions](../configuration/instructions.md)). |
-| `initialized` (notification) | Marks the session as ready. |
-| `tools/list` | Returns every registered tool with its JSON schema (derived from the Go input struct). |
-| `tools/call` | Invokes the named tool. Subject to the audit middleware. |
-| `notifications/progress` | Server → client. Emitted by the `progress` tool when the caller supplies a `progressToken`. |
+<div class="def-cards" markdown>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">initialize</code></div>
+<div class="def-card__body" markdown>Returns `serverInfo` (name, version), `capabilities`, `protocolVersion`, and `instructions` (see [Server Instructions](../configuration/instructions.md)).</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head">
+<code class="def-card__name">initialized</code>
+<div class="def-card__chips"><span class="def-card__chip"><span class="def-card__chip-label">kind</span><span class="def-card__chip-value">notification</span></span></div>
+</div>
+<div class="def-card__body" markdown>Marks the session as ready.</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">tools/list</code></div>
+<div class="def-card__body" markdown>Returns every registered tool with its JSON schema (derived from the Go input struct).</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head"><code class="def-card__name">tools/call</code></div>
+<div class="def-card__body" markdown>Invokes the named tool. Subject to the audit middleware.</div>
+</div>
+
+<div class="def-card" markdown>
+<div class="def-card__head">
+<code class="def-card__name">notifications/progress</code>
+<div class="def-card__chips"><span class="def-card__chip"><span class="def-card__chip-label">direction</span><span class="def-card__chip-value">server → client</span></span></div>
+</div>
+<div class="def-card__body" markdown>Emitted by the `progress` tool when the caller supplies a `progressToken`.</div>
+</div>
+
+</div>
 
 ## Tool schema
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1960,3 +1960,433 @@ html.plex-lightbox-open,
 html.plex-lightbox-open body {
   overflow: hidden;
 }
+
+/* ─────────────────────────────────────────────────────────────────────────
+   API endpoint cards: the HTTP-API reference layout.
+
+   Aesthetic: each endpoint is a horizontal card. Method pill on the left,
+   full mono path on a single no-wrap line so 50-char paths read as one
+   token instead of getting hyphenated mid-segment by a narrow Path
+   column. Description sits below in DM Sans body type, indented to align
+   with the path. The 3px left strip color-codes the verb in copper /
+   coral so the eye can scan a long list and pick out the POST / DELETE
+   rows without parsing each pill.
+
+   Vocabulary borrowed from the carousel slides + lightbox shell so the
+   docs site reads as one designed system, not a stack of unrelated
+   components.
+   ───────────────────────────────────────────────────────────────────── */
+
+/* Wrap the whole stack so the children share margins and we have a hook
+   for narrow-viewport tweaks. md_in_html requires `markdown` attr to
+   pass through; we render this in the source markdown. */
+.md-typeset .api-endpoints {
+  margin: 1.25rem 0 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.md-typeset .api-endpoint {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.45rem;
+  margin: 0;
+  padding: 0.85rem 1rem 0.9rem;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-left: 3px solid color-mix(in srgb, var(--copper-500) 35%, transparent);
+  border-radius: var(--plex-radius-md);
+  background: var(--md-default-bg-color);
+  transition: border-color 200ms ease, box-shadow 200ms ease,
+              background-color 200ms ease;
+}
+.md-typeset .api-endpoint:hover {
+  border-color: var(--copper-500);
+  box-shadow:
+    0 1px 2px rgba(15, 23, 42, 0.04),
+    0 14px 28px -18px rgba(20, 184, 171, 0.22);
+  background: color-mix(in srgb, var(--md-default-bg-color) 96%, var(--copper-500));
+}
+[data-md-color-scheme="slate"] .md-typeset .api-endpoint {
+  background: var(--midnight-900);
+  border-color: var(--midnight-800);
+  border-left-color: color-mix(in srgb, var(--copper-400) 45%, transparent);
+}
+[data-md-color-scheme="slate"] .md-typeset .api-endpoint:hover {
+  border-color: var(--copper-400);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.4),
+    0 14px 28px -18px rgba(45, 211, 203, 0.28);
+  background: color-mix(in srgb, var(--midnight-900) 92%, var(--copper-700));
+}
+
+/* Per-method left-strip accent. The color choice keeps GET in the brand
+   teal (read, frequent), POST one step deeper (write), DELETE in a
+   muted coral (destructive but not traffic-light red). Same accents
+   inform the method pill below. */
+.md-typeset .api-endpoint--get    { border-left-color: var(--copper-400); }
+.md-typeset .api-endpoint--post   { border-left-color: var(--copper-700); }
+.md-typeset .api-endpoint--delete { border-left-color: #b04829; }
+.md-typeset .api-endpoint--put    { border-left-color: var(--copper-600); }
+.md-typeset .api-endpoint--patch  { border-left-color: var(--copper-600); }
+
+[data-md-color-scheme="slate"] .md-typeset .api-endpoint--get    { border-left-color: var(--copper-300); }
+[data-md-color-scheme="slate"] .md-typeset .api-endpoint--post   { border-left-color: var(--copper-400); }
+[data-md-color-scheme="slate"] .md-typeset .api-endpoint--delete { border-left-color: #e8836a; }
+[data-md-color-scheme="slate"] .md-typeset .api-endpoint--put    { border-left-color: var(--copper-300); }
+[data-md-color-scheme="slate"] .md-typeset .api-endpoint--patch  { border-left-color: var(--copper-300); }
+
+/* The header row: method pill + path on one line. flex-nowrap so the
+   path takes the remaining width and overflows horizontally rather
+   than dropping below the pill. */
+.md-typeset .api-endpoint__head {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  min-width: 0;
+}
+
+.md-typeset .api-endpoint__method {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 3.6em;
+  padding: 0.18rem 0.6rem;
+  border-radius: 999px;
+  font-family: "DM Sans", system-ui, sans-serif;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-feature-settings: "tnum" 1;
+  border: 1px solid transparent;
+  /* Override Material's default badge / code styling that .md-typeset
+     might apply via cascade. */
+  background: transparent;
+  color: var(--md-default-fg-color);
+}
+
+.md-typeset .api-endpoint__method--get {
+  background: color-mix(in srgb, var(--copper-500) 12%, transparent);
+  color: var(--copper-800);
+  border-color: color-mix(in srgb, var(--copper-500) 35%, transparent);
+}
+.md-typeset .api-endpoint__method--post {
+  background: color-mix(in srgb, var(--copper-700) 16%, transparent);
+  color: var(--copper-900);
+  border-color: color-mix(in srgb, var(--copper-700) 45%, transparent);
+}
+.md-typeset .api-endpoint__method--delete {
+  background: rgba(176, 72, 41, 0.12);
+  color: #8b3a23;
+  border-color: rgba(176, 72, 41, 0.40);
+}
+[data-md-color-scheme="slate"] .md-typeset .api-endpoint__method--get {
+  background: color-mix(in srgb, var(--copper-400) 18%, transparent);
+  color: var(--copper-200);
+  border-color: color-mix(in srgb, var(--copper-400) 50%, transparent);
+}
+[data-md-color-scheme="slate"] .md-typeset .api-endpoint__method--post {
+  background: color-mix(in srgb, var(--copper-500) 22%, transparent);
+  color: var(--copper-100);
+  border-color: color-mix(in srgb, var(--copper-500) 55%, transparent);
+}
+[data-md-color-scheme="slate"] .md-typeset .api-endpoint__method--delete {
+  background: rgba(232, 131, 106, 0.18);
+  color: #f0a896;
+  border-color: rgba(232, 131, 106, 0.45);
+}
+
+/* The path. Critical no-wrap behavior: white-space:nowrap +
+   overflow-x:auto so a 60-char path is readable as a single token,
+   horizontally scrollable on narrow viewports rather than broken. */
+.md-typeset .api-endpoint__path {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-family: var(--md-code-font, ui-monospace, "SF Mono", "Menlo", monospace);
+  font-size: 0.9rem;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  color: var(--md-default-fg-color);
+  background: transparent;
+  padding: 0;
+  border: 0;
+  white-space: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+  scrollbar-color: var(--copper-500) transparent;
+}
+.md-typeset .api-endpoint__path::-webkit-scrollbar { height: 4px; }
+.md-typeset .api-endpoint__path::-webkit-scrollbar-track { background: transparent; }
+.md-typeset .api-endpoint__path::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--copper-500) 60%, transparent);
+  border-radius: 2px;
+}
+[data-md-color-scheme="slate"] .md-typeset .api-endpoint__path { color: #fff; }
+
+/* Body: description text in the same body type as the rest of the site,
+   indented to align under the path's left edge so the eye doesn't have
+   to reset. Keeps inline code, emphasis, and links rendering naturally
+   via md_in_html. */
+.md-typeset .api-endpoint__body {
+  font-family: "DM Sans", system-ui, sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  color: var(--md-default-fg-color--light);
+  /* Indent under the method pill so the description aligns with where
+     the path text starts (3.6em min-width pill + 0.6rem gap ≈ 4.5rem). */
+  padding-left: calc(3.6em + 0.6rem);
+  margin: 0;
+}
+.md-typeset .api-endpoint__body > :first-child { margin-top: 0; }
+.md-typeset .api-endpoint__body > :last-child  { margin-bottom: 0; }
+.md-typeset .api-endpoint__body p {
+  margin: 0 0 0.4rem;
+}
+.md-typeset .api-endpoint__body p:last-child { margin-bottom: 0; }
+.md-typeset .api-endpoint__body code {
+  /* Material's default inline-code chrome stays; just ensure it doesn't
+     collide visually with the path mono. */
+  font-size: 0.82rem;
+}
+[data-md-color-scheme="slate"] .md-typeset .api-endpoint__body { color: var(--midnight-200); }
+
+/* Inline meta block for endpoints with extra structured info (Body +
+   Returns columns from the old Admin table). Renders as a small
+   key/value pair line under the description. */
+.md-typeset .api-endpoint__meta {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.25rem 0.85rem;
+  margin-top: 0.45rem;
+  font-family: "DM Sans", system-ui, sans-serif;
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+.md-typeset .api-endpoint__meta dt {
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--copper-700);
+  padding-top: 0.18rem;
+  margin: 0;
+}
+[data-md-color-scheme="slate"] .md-typeset .api-endpoint__meta dt { color: var(--copper-300); }
+.md-typeset .api-endpoint__meta dd {
+  margin: 0;
+  color: var(--md-default-fg-color--light);
+  min-width: 0;
+}
+[data-md-color-scheme="slate"] .md-typeset .api-endpoint__meta dd { color: var(--midnight-200); }
+
+/* Narrow-viewport: drop the body indent so the description gets the
+   full row width. The horizontal-scroll path stays the same. */
+@media (max-width: 720px) {
+  .md-typeset .api-endpoint__body { padding-left: 0; }
+  .md-typeset .api-endpoint__head { gap: 0.5rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .md-typeset .api-endpoint { transition: none; }
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+   Config-key cards: same vocabulary as the API endpoint cards, used
+   for the YAML reference and the env-var listings. The key (e.g.
+   `server.streamable.session_timeout`, `MCPTEST_OIDC_CLIENT_SECRET`)
+   gets the top line on its own so a 40-char dotted path doesn't
+   hyphenate mid-segment into a narrow Key column. Type / default chips
+   on the right of the head; notes prose below.
+   ───────────────────────────────────────────────────────────────────── */
+
+.md-typeset .config-keys,
+.md-typeset .def-cards {
+  margin: 1.25rem 0 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.md-typeset .config-key,
+.md-typeset .def-card {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.45rem;
+  margin: 0;
+  padding: 0.85rem 1rem 0.9rem;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-left: 3px solid color-mix(in srgb, var(--copper-500) 35%, transparent);
+  border-radius: var(--plex-radius-md);
+  background: var(--md-default-bg-color);
+  transition: border-color 200ms ease, box-shadow 200ms ease,
+              background-color 200ms ease;
+}
+.md-typeset .config-key:hover,
+.md-typeset .def-card:hover {
+  border-color: var(--copper-500);
+  box-shadow:
+    0 1px 2px rgba(15, 23, 42, 0.04),
+    0 14px 28px -18px rgba(20, 184, 171, 0.22);
+  background: color-mix(in srgb, var(--md-default-bg-color) 96%, var(--copper-500));
+}
+[data-md-color-scheme="slate"] .md-typeset .config-key,
+[data-md-color-scheme="slate"] .md-typeset .def-card {
+  background: var(--midnight-900);
+  border-color: var(--midnight-800);
+  border-left-color: color-mix(in srgb, var(--copper-400) 45%, transparent);
+}
+[data-md-color-scheme="slate"] .md-typeset .config-key:hover,
+[data-md-color-scheme="slate"] .md-typeset .def-card:hover {
+  border-color: var(--copper-400);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.4),
+    0 14px 28px -18px rgba(45, 211, 203, 0.28);
+  background: color-mix(in srgb, var(--midnight-900) 92%, var(--copper-700));
+}
+
+/* Required vs optional left strips. Most keys are optional; mark a
+   handful as required (e.g. `oidc.issuer` when oidc.enabled). */
+.md-typeset .config-key--required { border-left-color: var(--copper-700); }
+[data-md-color-scheme="slate"] .md-typeset .config-key--required { border-left-color: var(--copper-300); }
+
+/* The head is a fixed two-row stack: key on row 1, chips on row 2.
+   Forcing a column (rather than flex-wrap) means the chips sit in the
+   same place on every card regardless of the key's length, which is
+   what the eye expects when scanning a long list. */
+.md-typeset .config-key__head,
+.md-typeset .def-card__head {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.45rem;
+  min-width: 0;
+}
+
+/* Key name: bold mono, copper accent. Allowed to wrap at any character
+   when a single segment exceeds the row, but in practice every key
+   here fits on one line at the standard mkdocs content width. */
+.md-typeset code.config-key__name,
+.md-typeset code.def-card__name {
+  display: block;
+  width: 100%;
+  font-family: var(--md-code-font, ui-monospace, "SF Mono", "Menlo", monospace);
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  color: var(--copper-800);
+  background: transparent;
+  padding: 0;
+  border: 0;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+[data-md-color-scheme="slate"] .md-typeset code.config-key__name,
+[data-md-color-scheme="slate"] .md-typeset code.def-card__name { color: var(--copper-200); }
+
+/* Chip row: always on its own line below the key so type/default
+   anchor in the same horizontal slot on every card. */
+.md-typeset .config-key__chips,
+.md-typeset .def-card__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.md-typeset .config-key__chip,
+.md-typeset .def-card__chip {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  padding: 0.18rem 0.55rem 0.2rem;
+  border-radius: 999px;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  background: color-mix(in srgb, var(--md-default-bg-color) 92%, var(--copper-500));
+  font-family: "DM Sans", system-ui, sans-serif;
+  font-size: 0.72rem;
+  line-height: 1.2;
+  color: var(--md-default-fg-color);
+}
+[data-md-color-scheme="slate"] .md-typeset .config-key__chip,
+[data-md-color-scheme="slate"] .md-typeset .def-card__chip {
+  background: color-mix(in srgb, var(--midnight-900) 88%, var(--copper-700));
+  border-color: var(--midnight-800);
+  color: #fff;
+}
+
+.md-typeset .config-key__chip-label,
+.md-typeset .def-card__chip-label {
+  font-size: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--copper-700);
+}
+[data-md-color-scheme="slate"] .md-typeset .config-key__chip-label,
+[data-md-color-scheme="slate"] .md-typeset .def-card__chip-label { color: var(--copper-300); }
+
+.md-typeset .config-key__chip-value,
+.md-typeset .config-key__chip code,
+.md-typeset .def-card__chip-value,
+.md-typeset .def-card__chip code {
+  font-family: var(--md-code-font, ui-monospace, "SF Mono", "Menlo", monospace);
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  color: var(--md-default-fg-color);
+  background: transparent;
+  padding: 0;
+  border: 0;
+}
+[data-md-color-scheme="slate"] .md-typeset .config-key__chip-value,
+[data-md-color-scheme="slate"] .md-typeset .config-key__chip code,
+[data-md-color-scheme="slate"] .md-typeset .def-card__chip-value,
+[data-md-color-scheme="slate"] .md-typeset .def-card__chip code { color: #fff; }
+
+/* `default` chip carries an emphasized copper border so the eye finds
+   the default value in a long list. */
+.md-typeset .config-key__chip--default {
+  border-color: color-mix(in srgb, var(--copper-500) 50%, transparent);
+  background: color-mix(in srgb, var(--md-default-bg-color) 88%, var(--copper-500));
+}
+[data-md-color-scheme="slate"] .md-typeset .config-key__chip--default {
+  border-color: color-mix(in srgb, var(--copper-400) 55%, transparent);
+  background: color-mix(in srgb, var(--midnight-900) 78%, var(--copper-700));
+}
+
+/* `required` chip: distinct rust tone so missing-required errors map
+   visually to the keys that produce them. */
+.md-typeset .config-key__chip--required {
+  border-color: rgba(176, 72, 41, 0.50);
+  background: rgba(176, 72, 41, 0.10);
+}
+.md-typeset .config-key__chip--required .config-key__chip-label { color: #8b3a23; }
+[data-md-color-scheme="slate"] .md-typeset .config-key__chip--required {
+  border-color: rgba(232, 131, 106, 0.55);
+  background: rgba(232, 131, 106, 0.16);
+}
+[data-md-color-scheme="slate"] .md-typeset .config-key__chip--required .config-key__chip-label { color: #f0a896; }
+
+.md-typeset .config-key__body,
+.md-typeset .def-card__body {
+  font-family: "DM Sans", system-ui, sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  color: var(--md-default-fg-color--light);
+  margin: 0;
+}
+.md-typeset .config-key__body > :first-child { margin-top: 0; }
+.md-typeset .config-key__body > :last-child { margin-bottom: 0; }
+.md-typeset .config-key__body p { margin: 0 0 0.4rem; }
+.md-typeset .config-key__body p:last-child { margin-bottom: 0; }
+.md-typeset .config-key__body code { font-size: 0.82rem; }
+[data-md-color-scheme="slate"] .md-typeset .config-key__body,
+[data-md-color-scheme="slate"] .md-typeset .def-card__body { color: var(--midnight-200); }
+
+@media (prefers-reduced-motion: reduce) {
+  .md-typeset .config-key,
+  .md-typeset .def-card { transition: none; }
+}

--- a/examples/kubernetes/00-namespace.yaml
+++ b/examples/kubernetes/00-namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mcp-test
+  labels:
+    app.kubernetes.io/name: mcp-test
+    app.kubernetes.io/part-of: mcp-test
+    app.kubernetes.io/managed-by: manifest

--- a/examples/kubernetes/10-postgres-service.yaml
+++ b/examples/kubernetes/10-postgres-service.yaml
@@ -1,0 +1,25 @@
+# Headless ClusterIP for the Postgres StatefulSet. mcp-test reaches the
+# DB via DNS name `postgres.mcp-test.svc.cluster.local:5432`. Headless
+# (clusterIP: None) gives the StatefulSet a stable per-pod DNS record
+# (`postgres-0.postgres...`); the connection string in 20-mcp-test-secret
+# uses the unqualified `postgres` host because both pods share a
+# namespace and DNS resolves it.
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: mcp-test
+  labels:
+    app: postgres
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/component: db
+    app.kubernetes.io/part-of: mcp-test
+spec:
+  clusterIP: None
+  selector:
+    app: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+      protocol: TCP

--- a/examples/kubernetes/12-postgres-secret.yaml
+++ b/examples/kubernetes/12-postgres-secret.yaml
@@ -1,0 +1,23 @@
+# Postgres credentials. Used by both the postgres container (POSTGRES_*
+# env) and built into the mcp-test connection string in
+# 20-mcp-test-secret. The install.sh script will fill the empty fields
+# below with a random password on first run; pre-filling them here lets
+# you commit a fixed password to a private fork if you want stable creds
+# across reinstalls.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres
+  namespace: mcp-test
+  labels:
+    app: postgres
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/component: db
+    app.kubernetes.io/part-of: mcp-test
+type: Opaque
+stringData:
+  POSTGRES_DB: mcp_test
+  POSTGRES_USER: mcp
+  # REPLACE: 24+ char random string (e.g. `openssl rand -base64 24`).
+  # install.sh writes one for you on a fresh install.
+  POSTGRES_PASSWORD: "REPLACE_ME_POSTGRES_PASSWORD"

--- a/examples/kubernetes/14-postgres-statefulset.yaml
+++ b/examples/kubernetes/14-postgres-statefulset.yaml
@@ -1,0 +1,92 @@
+# Single-replica Postgres for the mcp-test audit log + DB-backed API
+# keys. 5Gi PVC sized for ~50M audit_events rows at the default
+# 30-day retention with payloads on. Bump the storage request before
+# scale-out demos.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: mcp-test
+  labels:
+    app: postgres
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/component: db
+    app.kubernetes.io/part-of: mcp-test
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+        app.kubernetes.io/name: postgres
+        app.kubernetes.io/component: db
+        app.kubernetes.io/part-of: mcp-test
+    spec:
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        runAsUser: 70 # postgres uid in the alpine image
+        runAsGroup: 70
+        fsGroup: 70
+      containers:
+        - name: postgres
+          image: postgres:17-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: postgres
+              containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: postgres
+                  key: POSTGRES_DB
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres
+                  key: POSTGRES_PASSWORD
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "mcp", "-d", "mcp_test"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "mcp", "-d", "mcp_test"]
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 5Gi
+        # storageClassName: REPLACE_ME (omit to use cluster default)

--- a/examples/kubernetes/20-mcp-test-secret.yaml
+++ b/examples/kubernetes/20-mcp-test-secret.yaml
@@ -1,0 +1,34 @@
+# Application secrets for mcp-test:
+#   - DATABASE_URL: full Postgres connection string. Built from the
+#     postgres credentials so this manifest is self-contained for
+#     installs that bundle Postgres in-cluster (the default). For an
+#     external Postgres, replace this with your own URL.
+#   - COOKIE_SECRET: HMAC key for the portal's session cookie. ANY
+#     32+ random bytes; rotating invalidates all live sessions.
+#   - DEV_KEY: bootstrap API key. Sent as `X-API-Key: <value>` to MCP
+#     and admin endpoints; matches the `api_keys.file` entry in the
+#     ConfigMap.
+#
+# install.sh fills the empty fields below with `openssl rand` output
+# on a fresh install. The DATABASE_URL also references the postgres
+# password; the script regenerates the URL whenever it touches the
+# postgres secret to keep them in sync.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mcp-test
+  namespace: mcp-test
+  labels:
+    app: mcp-test
+    app.kubernetes.io/name: mcp-test
+    app.kubernetes.io/component: server
+    app.kubernetes.io/part-of: mcp-test
+type: Opaque
+stringData:
+  # postgres://USER:PASSWORD@HOST:5432/DB?sslmode=disable
+  DATABASE_URL: "REPLACE_ME_DATABASE_URL"
+  # 32 bytes base64 (e.g. `openssl rand -base64 32`)
+  COOKIE_SECRET: "REPLACE_ME_COOKIE_SECRET"
+  # API key sent as `X-API-Key`. Use a long random value or the
+  # mcptest_-prefixed format the dev tooling produces.
+  DEV_KEY: "REPLACE_ME_DEV_API_KEY"

--- a/examples/kubernetes/25-mcp-test-configmap.yaml
+++ b/examples/kubernetes/25-mcp-test-configmap.yaml
@@ -1,0 +1,91 @@
+# mcp-test runtime config. The container reads this from
+# /etc/mcp-test/mcp-test.yaml; see 40-mcp-test-deployment.yaml.
+#
+# Defaults below ship a working installation with:
+#   - API-key auth only (OIDC disabled). Operators authenticate by
+#     pasting the dev key on the portal login screen, and MCP clients
+#     send `X-API-Key: <DEV_KEY>`. To turn on OIDC instead, set
+#     `oidc.enabled: true` and supply issuer + client credentials via
+#     additional secret keys + env mappings in the Deployment.
+#   - Audit log fully on, payloads + headers captured, 30-day retention.
+#   - Portal at /portal/, MCP at /, behind the same Ingress.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcp-test
+  namespace: mcp-test
+  labels:
+    app: mcp-test
+    app.kubernetes.io/name: mcp-test
+    app.kubernetes.io/component: server
+    app.kubernetes.io/part-of: mcp-test
+data:
+  mcp-test.yaml: |
+    server:
+      name: mcp-test
+      address: ":8080"
+      # REPLACE: must match the public URL clients reach this server at.
+      # Used in OIDC redirects (when enabled) and RFC 9728 metadata.
+      base_url: "https://mcp-test-server.example.com"
+      read_header_timeout: 10s
+      shutdown:
+        grace_period: 25s
+        pre_shutdown_delay: 2s
+      tls:
+        enabled: false
+      streamable:
+        session_timeout: 30m
+        stateless: false
+        json_response: false
+
+    oidc:
+      enabled: false
+      # When you flip enabled to true, supply these via env from a
+      # secret you add yourself. The defaults below match the dev
+      # Keycloak; replace with your real issuer.
+      # issuer: "https://your-idp.example.com/realms/mcp-test"
+      # audience: "mcp-test"
+      # client_id: "${MCPTEST_OIDC_CLIENT_ID}"
+      # client_secret: "${MCPTEST_OIDC_CLIENT_SECRET}"
+
+    api_keys:
+      file:
+        - name: bootstrap
+          key: "${MCPTEST_DEV_KEY}"
+          description: "Bootstrap API key for portal admin and MCP smoke tests"
+      db:
+        enabled: true
+
+    auth:
+      allow_anonymous: false
+      require_for_mcp: true
+      require_for_portal: true
+
+    database:
+      url: "${MCPTEST_DATABASE_URL}"
+      max_open_conns: 25
+      max_idle_conns: 5
+      conn_max_lifetime: 1h
+
+    audit:
+      enabled: true
+      capture_payloads: true
+      capture_headers: true
+      max_payload_bytes: 65536
+      retention_days: 30
+      redact_keys: [password, token, secret, authorization, api_key, credentials, cookie]
+
+    portal:
+      enabled: true
+      cookie_name: mcp_test_session
+      cookie_secret: "${MCPTEST_COOKIE_SECRET}"
+      # cookie_secure must be false when serving over plain HTTP locally;
+      # leave true for the Ingress + cert-manager flow this example uses.
+      cookie_secure: true
+      oidc_redirect_path: /portal/auth/callback
+
+    tools:
+      identity:  { enabled: true }
+      data:      { enabled: true }
+      failure:   { enabled: true }
+      streaming: { enabled: true }

--- a/examples/kubernetes/30-mcp-test-service.yaml
+++ b/examples/kubernetes/30-mcp-test-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-test
+  namespace: mcp-test
+  labels:
+    app: mcp-test
+    app.kubernetes.io/name: mcp-test
+    app.kubernetes.io/component: server
+    app.kubernetes.io/part-of: mcp-test
+spec:
+  type: ClusterIP
+  selector:
+    app: mcp-test
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: http

--- a/examples/kubernetes/40-mcp-test-deployment.yaml
+++ b/examples/kubernetes/40-mcp-test-deployment.yaml
@@ -1,0 +1,102 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-test
+  namespace: mcp-test
+  labels:
+    app: mcp-test
+    app.kubernetes.io/name: mcp-test
+    app.kubernetes.io/component: server
+    app.kubernetes.io/part-of: mcp-test
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app: mcp-test
+  template:
+    metadata:
+      labels:
+        app: mcp-test
+        app.kubernetes.io/name: mcp-test
+        app.kubernetes.io/component: server
+        app.kubernetes.io/part-of: mcp-test
+      annotations:
+        # Force a rollout when ConfigMap or Secret content changes.
+        # install.sh patches these to a SHA256 of the on-disk file
+        # contents; replace manually with `kubectl rollout restart` if
+        # you edit the manifests outside the script.
+        config-hash: "0"
+        secret-hash: "0"
+    spec:
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: mcp-test
+          image: ghcr.io/plexara/mcp-test:v1.2.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config
+            - /etc/mcp-test/mcp-test.yaml
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: MCPTEST_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: mcp-test
+                  key: DATABASE_URL
+            - name: MCPTEST_COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: mcp-test
+                  key: COOKIE_SECRET
+            - name: MCPTEST_DEV_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mcp-test
+                  key: DEV_KEY
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mcp-test
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      volumes:
+        - name: config
+          configMap:
+            name: mcp-test

--- a/examples/kubernetes/50-mcp-test-ingress.yaml
+++ b/examples/kubernetes/50-mcp-test-ingress.yaml
@@ -1,0 +1,53 @@
+# Ingress for mcp-test. Assumes:
+#   - ingress-nginx as the controller (annotations are nginx-specific).
+#     Adjust for traefik / aws-load-balancer-controller / etc.
+#   - cert-manager with a `letsencrypt-production` ClusterIssuer for
+#     automated TLS. Remove the `cert-manager.io/cluster-issuer`
+#     annotation and the `tls:` block if you handle TLS at a different
+#     layer (terminating LB, service mesh, etc.).
+#
+# REPLACE: `mcp-test-server.example.com` (3 occurrences below) with the
+# DNS name your Ingress controller routes to this service.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mcp-test
+  namespace: mcp-test
+  labels:
+    app: mcp-test
+    app.kubernetes.io/name: mcp-test
+    app.kubernetes.io/component: server
+    app.kubernetes.io/part-of: mcp-test
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    # CORS: lets a browser-side MCP gateway call this server. Tighten
+    # the allow-origin list to the gateway hosts you actually use.
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, DELETE, OPTIONS"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "*"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+    # Streamable HTTP / SSE: long-lived connections for live tail and
+    # MCP server-initiated messages. Disable buffering so the client
+    # sees frames as they're written.
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-buffering: "off"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
+    nginx.ingress.kubernetes.io/service-upstream: "true"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: mcp-test-server.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mcp-test
+                port:
+                  number: 8080
+  tls:
+    - hosts:
+        - mcp-test-server.example.com
+      secretName: mcp-test-tls

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -1,0 +1,96 @@
+# Kubernetes example
+
+A self-contained installation of `mcp-test` and a single-replica Postgres on any Kubernetes cluster with an `nginx` ingress controller and a working `cert-manager` `letsencrypt-production` ClusterIssuer. One file per resource, numeric ordering, applied with `install.sh` (or any GitOps tool that consumes plain `kubectl apply -f` input).
+
+## What lands
+
+| File | Resource |
+| --- | --- |
+| `00-namespace.yaml`         | `Namespace mcp-test` |
+| `10-postgres-service.yaml`  | `Service postgres` (headless ClusterIP) |
+| `12-postgres-secret.yaml`   | `Secret postgres` (DB / user / password) |
+| `14-postgres-statefulset.yaml` | `StatefulSet postgres` (single replica, 5Gi PVC, `postgres:17-alpine`) |
+| `20-mcp-test-secret.yaml`   | `Secret mcp-test` (`DATABASE_URL` / `COOKIE_SECRET` / `DEV_KEY`) |
+| `25-mcp-test-configmap.yaml`| `ConfigMap mcp-test` (full `mcp-test.yaml`; OIDC off, API-key auth, audit on) |
+| `30-mcp-test-service.yaml`  | `Service mcp-test` (ClusterIP, port 8080) |
+| `40-mcp-test-deployment.yaml`| `Deployment mcp-test` (`ghcr.io/plexara/mcp-test:v1.2.0`) |
+| `50-mcp-test-ingress.yaml`  | `Ingress mcp-test` (TLS via cert-manager, CORS for browser MCP gateways) |
+
+`install.sh` wires the secrets to each other (the postgres password is reused inside the `DATABASE_URL`) and patches a `config-hash` / `secret-hash` annotation on the Deployment so a re-run after a config edit rolls the pod automatically.
+
+## Placeholders
+
+Three things you replace before this is yours:
+
+1. **Ingress host.** `mcp-test-server.example.com` appears once in `50-mcp-test-ingress.yaml` (and in `25-mcp-test-configmap.yaml` as `server.base_url`). `install.sh` will prompt for `INGRESS_HOST` if you haven't set it; it rewrites the ingress in-place. Update `base_url` in the ConfigMap by hand if you change it.
+2. **Postgres password.** `REPLACE_ME_POSTGRES_PASSWORD` in `12-postgres-secret.yaml`. `install.sh` writes a random 28-char value on first run.
+3. **Application secrets.** `REPLACE_ME_COOKIE_SECRET`, `REPLACE_ME_DEV_API_KEY`, `REPLACE_ME_DATABASE_URL` in `20-mcp-test-secret.yaml`. `install.sh` generates and prints the dev API key on first run.
+
+Everything else is functional defaults.
+
+## Install
+
+```sh
+# from this directory
+./install.sh
+```
+
+The script will:
+
+1. Confirm the current `kubectl` context.
+2. Generate the secret values in-place where they're still placeholders.
+3. Apply manifests in numeric order with `[N/M]` progress.
+4. Wait for `pod/postgres-0` to be Ready before applying the mcp-test side.
+5. Wait for the mcp-test Deployment rollout.
+6. Print the URLs and the dev API key.
+
+Variables it honors:
+
+| Var | Default | Purpose |
+| --- | --- | --- |
+| `INGRESS_HOST` | prompts | DNS name your ingress controller routes to mcp-test (e.g. `mcp.example.com`). |
+| `KUBE_CONTEXT` | current | kubectl context to install into. |
+| `--dry-run` | off | Renders manifests, doesn't apply. |
+
+## Smoke test
+
+Once the install finishes:
+
+```sh
+HOST="https://${INGRESS_HOST:-mcp-test-server.example.com}"
+KEY="<value printed by install.sh>"
+
+curl -i "${HOST}/healthz"
+
+curl -i -H "X-API-Key: ${KEY}" \
+  "${HOST}/api/v1/portal/me"
+
+# Initialize the MCP session, then call a tool.
+curl -i -X POST "${HOST}/" \
+  -H "X-API-Key: ${KEY}" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","clientInfo":{"name":"smoketest","version":"0.1"},"capabilities":{}}}'
+```
+
+Then open the portal at `https://${INGRESS_HOST}/portal/` and paste the same `X-API-Key` value into the login screen.
+
+## Variations
+
+**External Postgres.** Drop `10-postgres-service.yaml`, `12-postgres-secret.yaml`, `14-postgres-statefulset.yaml`, and replace the `DATABASE_URL` field in `20-mcp-test-secret.yaml` with your own connection string. Make sure your CA chain is trusted by the mcp-test pod if you use `sslmode=verify-full`.
+
+**OIDC instead of API keys.** In `25-mcp-test-configmap.yaml`, set `oidc.enabled: true`, fill `oidc.issuer` and `oidc.audience`, and add an `MCPTEST_OIDC_CLIENT_ID` / `MCPTEST_OIDC_CLIENT_SECRET` env mapping in the Deployment from a secret you create. The `mcp-test` repo's OIDC docs at `docs/configuration/auth.md` walk the full flow.
+
+**Different ingress controller.** The annotations in `50-mcp-test-ingress.yaml` are nginx-specific. For traefik / aws-load-balancer-controller / gke ingress, swap them for the equivalent timeout / CORS / buffer-disable annotations. The `ingressClassName` line also needs to match.
+
+**Plain HTTP for local clusters.** Drop the `tls:` block in the ingress and set `portal.cookie_secure: false` in the ConfigMap. Cookies won't survive a session otherwise.
+
+**Higher replicas.** mcp-test is stateless once Postgres is reachable. Bump `replicas` on the Deployment; the StatefulSet stays at 1. The audit log uses Postgres advisory locks for the serial migration step on startup, so concurrent rollouts converge correctly.
+
+## Uninstall
+
+```sh
+kubectl delete namespace mcp-test
+```
+
+The PVC bound by the Postgres StatefulSet is in the namespace and goes with it. To preserve audit data across reinstalls, change `volumeClaimTemplates.metadata.annotations` to add `helm.sh/resource-policy: keep` or apply a finalizer; out of scope for this example.

--- a/examples/kubernetes/install.sh
+++ b/examples/kubernetes/install.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+#
+# install.sh: apply the mcp-test example to a Kubernetes cluster with
+# progress output. Idempotent: re-running safely re-applies every
+# manifest and patches a fresh config-hash / secret-hash so a config
+# change rolls the Deployment.
+#
+# What it does:
+#   1. Sanity checks (kubectl reachable, current context confirmed).
+#   2. Generates secrets in-place if the manifests still hold REPLACE_ME
+#      placeholders (postgres password, mcp-test cookie secret, dev API
+#      key, and the full DATABASE_URL built from the postgres password).
+#   3. Replaces `mcp-test-server.example.com` with $INGRESS_HOST in the
+#      Ingress manifest.
+#   4. Applies the manifests in numeric order with [N/M] progress.
+#   5. Waits for Postgres readiness before applying mcp-test, then waits
+#      for the Deployment rollout.
+#   6. Prints next steps with the URLs and the dev API key.
+#
+# Usage:
+#   ./install.sh                         # interactive: confirms context, prompts for INGRESS_HOST
+#   INGRESS_HOST=mcp.example.com ./install.sh
+#   INGRESS_HOST=mcp.example.com KUBE_CONTEXT=staging ./install.sh
+#   ./install.sh --dry-run               # render manifests, don't apply
+#
+# This script is intentionally simple bash; no helm, no kustomize. The
+# manifests are valid `kubectl apply -f` input on their own if you'd
+# rather wire them into your existing GitOps tool.
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+NAMESPACE="mcp-test"
+DRY_RUN="false"
+
+# ---------------------------------------------------------------------
+# tiny progress helpers
+# ---------------------------------------------------------------------
+
+c_reset='\033[0m'; c_bold='\033[1m'; c_dim='\033[2m'
+c_ok='\033[32m'; c_warn='\033[33m'; c_err='\033[31m'; c_step='\033[36m'
+
+step()    { printf "${c_step}[%d/%d]${c_reset} %b\n" "$1" "$TOTAL_STEPS" "$2"; }
+ok()      { printf "      ${c_ok}✓${c_reset} %b\n" "$1"; }
+warn()    { printf "      ${c_warn}!${c_reset} %b\n" "$1"; }
+fail()    { printf "      ${c_err}✗${c_reset} %b\n" "$1" >&2; exit 1; }
+hdr()     { printf "\n${c_bold}%s${c_reset}\n" "$1"; }
+muted()   { printf "${c_dim}%s${c_reset}\n" "$1"; }
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN="true" ;;
+    -h|--help)
+      sed -n '/^# install.sh/,/^# This script is/p' "$0" | sed 's/^# //; s/^#//'
+      exit 0 ;;
+  esac
+done
+
+# ---------------------------------------------------------------------
+# preflight
+# ---------------------------------------------------------------------
+
+hdr "mcp-test Kubernetes installer"
+
+command -v kubectl >/dev/null || fail "kubectl is not on PATH"
+command -v openssl >/dev/null || fail "openssl is not on PATH (used for secret generation)"
+
+if [[ -n "${KUBE_CONTEXT:-}" ]]; then
+  KCTX_ARGS=(--context "$KUBE_CONTEXT")
+else
+  KCTX_ARGS=()
+fi
+KCTX="$(kubectl "${KCTX_ARGS[@]}" config current-context 2>/dev/null || true)"
+[[ -n "$KCTX" ]] || fail "could not determine current kubectl context (try setting KUBE_CONTEXT=...)"
+
+printf "  context : %s\n" "$KCTX"
+printf "  namespace: %s\n" "$NAMESPACE"
+
+if [[ "$DRY_RUN" != "true" ]]; then
+  read -r -p "  apply to this context? [y/N] " confirm
+  [[ "$confirm" =~ ^[Yy]$ ]] || fail "aborted"
+fi
+
+# ---------------------------------------------------------------------
+# placeholder fill
+# ---------------------------------------------------------------------
+
+PG_SECRET="$SCRIPT_DIR/12-postgres-secret.yaml"
+APP_SECRET="$SCRIPT_DIR/20-mcp-test-secret.yaml"
+INGRESS="$SCRIPT_DIR/50-mcp-test-ingress.yaml"
+
+# Postgres password
+if grep -q 'REPLACE_ME_POSTGRES_PASSWORD' "$PG_SECRET"; then
+  pgpw="$(openssl rand -base64 24 | tr -d '\n=+/' | head -c 28)"
+  sed -i.bak "s|REPLACE_ME_POSTGRES_PASSWORD|${pgpw}|" "$PG_SECRET" && rm -f "$PG_SECRET.bak"
+  ok "generated POSTGRES_PASSWORD in 12-postgres-secret.yaml"
+else
+  pgpw="$(awk '/POSTGRES_PASSWORD:/ {gsub(/"/,"",$2); print $2; exit}' "$PG_SECRET")"
+  ok "POSTGRES_PASSWORD already set"
+fi
+
+# Application secrets
+if grep -q 'REPLACE_ME_COOKIE_SECRET' "$APP_SECRET"; then
+  cookie="$(openssl rand -base64 32 | tr -d '\n')"
+  sed -i.bak "s|REPLACE_ME_COOKIE_SECRET|${cookie}|" "$APP_SECRET" && rm -f "$APP_SECRET.bak"
+  ok "generated COOKIE_SECRET in 20-mcp-test-secret.yaml"
+fi
+if grep -q 'REPLACE_ME_DEV_API_KEY' "$APP_SECRET"; then
+  devkey="mcptest_$(openssl rand -base64 24 | tr -d '\n=+/' | head -c 32)"
+  sed -i.bak "s|REPLACE_ME_DEV_API_KEY|${devkey}|" "$APP_SECRET" && rm -f "$APP_SECRET.bak"
+  ok "generated DEV_KEY in 20-mcp-test-secret.yaml"
+else
+  devkey="$(awk '/DEV_KEY:/ {gsub(/"/,"",$2); print $2; exit}' "$APP_SECRET")"
+fi
+if grep -q 'REPLACE_ME_DATABASE_URL' "$APP_SECRET"; then
+  dburl="postgres://mcp:${pgpw}@postgres:5432/mcp_test?sslmode=disable"
+  # `|` is the sed delim so we don't fight the / in the URL.
+  sed -i.bak "s|REPLACE_ME_DATABASE_URL|${dburl}|" "$APP_SECRET" && rm -f "$APP_SECRET.bak"
+  ok "wrote DATABASE_URL in 20-mcp-test-secret.yaml"
+fi
+
+# Ingress host
+if grep -q 'mcp-test-server.example.com' "$INGRESS"; then
+  if [[ -z "${INGRESS_HOST:-}" ]]; then
+    if [[ "$DRY_RUN" == "true" ]]; then
+      INGRESS_HOST="mcp-test-server.example.com"
+      warn "INGRESS_HOST not set; --dry-run keeps the placeholder"
+    else
+      read -r -p "  ingress host (e.g. mcp.example.com): " INGRESS_HOST
+      [[ -n "$INGRESS_HOST" ]] || fail "INGRESS_HOST required"
+    fi
+  fi
+  if [[ "$INGRESS_HOST" != "mcp-test-server.example.com" ]]; then
+    sed -i.bak "s|mcp-test-server.example.com|${INGRESS_HOST}|g" "$INGRESS" && rm -f "$INGRESS.bak"
+    ok "set ingress host to ${INGRESS_HOST}"
+  fi
+fi
+
+# Compute hashes for the rollout-on-config-change annotations.
+config_hash="$(shasum -a 256 "$SCRIPT_DIR/25-mcp-test-configmap.yaml" | awk '{print substr($1,1,12)}')"
+secret_hash="$(shasum -a 256 "$APP_SECRET" | awk '{print substr($1,1,12)}')"
+
+# ---------------------------------------------------------------------
+# apply
+# ---------------------------------------------------------------------
+
+# Order matters: namespace first, then postgres up + ready, then
+# mcp-test secrets/configmap, then deployment, then ingress.
+MANIFESTS=(
+  "00-namespace.yaml"
+  "10-postgres-service.yaml"
+  "12-postgres-secret.yaml"
+  "14-postgres-statefulset.yaml"
+  "20-mcp-test-secret.yaml"
+  "25-mcp-test-configmap.yaml"
+  "30-mcp-test-service.yaml"
+  "40-mcp-test-deployment.yaml"
+  "50-mcp-test-ingress.yaml"
+)
+TOTAL_STEPS=$(( ${#MANIFESTS[@]} + 2 ))  # +2 for the postgres-ready and rollout waits
+
+apply() {
+  if [[ "$DRY_RUN" == "true" ]]; then
+    kubectl "${KCTX_ARGS[@]}" apply --dry-run=client -f "$1" >/dev/null
+  else
+    kubectl "${KCTX_ARGS[@]}" apply -f "$1" >/dev/null
+  fi
+}
+
+i=0
+for f in "${MANIFESTS[@]}"; do
+  i=$(( i + 1 ))
+  case "$f" in
+    14-postgres-statefulset.yaml)
+      step "$i" "applying ${c_bold}$f${c_reset}"
+      apply "$SCRIPT_DIR/$f"
+      ok "Postgres StatefulSet applied"
+      i=$(( i + 1 ))
+      step "$i" "waiting for Postgres pod ready..."
+      if [[ "$DRY_RUN" != "true" ]]; then
+        kubectl "${KCTX_ARGS[@]}" -n "$NAMESPACE" wait --for=condition=Ready pod/postgres-0 \
+          --timeout=180s >/dev/null 2>&1 || fail "postgres-0 did not become Ready in 180s"
+        ok "postgres-0 Ready"
+      else
+        muted "      (skipped in dry-run)"
+      fi
+      ;;
+    40-mcp-test-deployment.yaml)
+      # Patch the rollout-on-content-change annotations so a config or
+      # secret edit takes effect on the next install.sh.
+      step "$i" "applying ${c_bold}$f${c_reset} (config-hash=${config_hash}, secret-hash=${secret_hash})"
+      tmp="$(mktemp)"
+      sed -e "s|config-hash: \"0\"|config-hash: \"${config_hash}\"|" \
+          -e "s|secret-hash: \"0\"|secret-hash: \"${secret_hash}\"|" \
+          "$SCRIPT_DIR/$f" > "$tmp"
+      apply "$tmp"
+      rm -f "$tmp"
+      ok "mcp-test Deployment applied"
+      i=$(( i + 1 ))
+      step "$i" "waiting for mcp-test rollout..."
+      if [[ "$DRY_RUN" != "true" ]]; then
+        kubectl "${KCTX_ARGS[@]}" -n "$NAMESPACE" rollout status deploy/mcp-test \
+          --timeout=180s >/dev/null || fail "mcp-test rollout did not complete"
+        ok "mcp-test Ready"
+      else
+        muted "      (skipped in dry-run)"
+      fi
+      ;;
+    *)
+      step "$i" "applying ${c_bold}$f${c_reset}"
+      apply "$SCRIPT_DIR/$f"
+      ok "applied"
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------
+# done
+# ---------------------------------------------------------------------
+
+hdr "Installed."
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  muted "(dry-run only; no resources were created)"
+  exit 0
+fi
+
+host="${INGRESS_HOST:-mcp-test-server.example.com}"
+
+cat <<EOF
+  Portal       https://${host}/portal/
+  MCP endpoint https://${host}/
+  Discovery    https://${host}/.well-known/oauth-protected-resource
+
+  X-API-Key    ${devkey}
+
+Smoke test (replace TOKEN_OR_KEY appropriately):
+
+  curl -i https://${host}/healthz
+  curl -i -H "X-API-Key: ${devkey}" \\
+      https://${host}/api/v1/portal/me
+
+To roll out a config change:
+  edit 25-mcp-test-configmap.yaml or 20-mcp-test-secret.yaml, re-run ./install.sh
+
+To uninstall:
+  kubectl delete namespace ${NAMESPACE}
+EOF

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -158,5 +158,11 @@ plugins:
   - social:
       enabled: !ENV [CI, false]
       cards_layout_options:
+        # Match the rest of the site: midnight-950 background, slate-50
+        # foreground, Outfit display (the same display font used in the
+        # carousel headings and lightbox title) for the page-title text.
+        # Google Fonts is reachable from the GitHub Actions runner, so
+        # the plugin can fetch the woff2 at render time.
         background_color: "#020617"
         color: "#f8fafc"
+        font_family: Outfit

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,3 +148,15 @@ markdown_extensions:
 plugins:
   - search:
       separator: '[\s\-,:!=\[\]()"`/]+|\.(?!\d)|&[lg]t;|(?!\b)(?=[A-Z][a-z])'
+  # Social plugin: generates 1200x630 PNG cards per page baked with the
+  # page title, eyebrow, and Plexara logo. Twitter/X picks `summary_large_image`
+  # when the OG image is large; without these cards every page falls back
+  # to the 378x338 logo.png and gets a small `summary` card. Gated on the
+  # CI env var so a local build without `mkdocs-material[imaging]` (and
+  # the cairo system deps) still works; the deploy workflow exports
+  # CI=true so production renders cards.
+  - social:
+      enabled: !ENV [CI, false]
+      cards_layout_options:
+        background_color: "#020617"
+        color: "#f8fafc"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
       - Inspection workflow: operations/inspection.md
       - Portal: operations/portal.md
       - Deployment: operations/deployment.md
+      - Kubernetes example: operations/kubernetes.md
       - Testing a Gateway: operations/gateway-testing.md
   - Reference:
       - HTTP API: reference/http-api.md


### PR DESCRIPTION
Three threads of post-v1.2.0 docs polish, bundled because they all surfaced together while reviewing the live site against the v1.2.0 release.

## Summary

- **Identifier-shaped tokens never wrap mid-character again.** Markdown tables hyphenate backtick'd identifiers when columns are narrow (`auth.allow_anonymous` rendered as `auth.all` / `ow_anony` / `mous`; `00-namespace.yaml` rendered as `00-namespace.yam` / `l`). Three new card components (`.api-endpoint`, `.config-key`, `.def-card`) anchor the identifier on its own line at full row width with type/default chips locked to a second line. Conversions across 9 docs pages (43 config keys, 30 HTTP endpoints, route lists, surface lists, method lists, file-system paths).
- **Self-contained Kubernetes example.** New `examples/kubernetes/` with one file per resource (Namespace + Postgres Service/Secret/StatefulSet + mcp-test Secret/ConfigMap/Service/Deployment/Ingress) and a bash installer that generates secrets in-place, applies in numeric order with `[N/M]` progress, gates on Postgres readiness, patches a config-hash/secret-hash so config edits trigger rollouts. Documented at `docs/operations/kubernetes.md` with each manifest's full YAML embedded inline (verbatim from disk; a python check enforces no drift between embeds and source).
- **SEO surface aligned with v1.2.** `llms.txt` updated with the new Operations pages. mkdocs-material's `social` plugin enabled (gated `enabled: !ENV [CI, false]` so dev builds without imaging deps still work). On deploy, every page gets a 1200×630 PNG card baked with its title, description, and Plexara typography (Outfit display, midnight + slate palette), so Twitter/X switches from `summary` to `summary_large_image` and Slack/LinkedIn previews look intentional.

Plus: ASCII box-drawing diagrams in `gateway-testing.md` converted to mermaid (`flowchart LR` for client/gateway/mcp-test/audit topology, `sequenceDiagram autonumber` for the identity-forwarding contrast).

## Files

| Area | Files | Change |
|---|---|---|
| **CSS components** | `docs/stylesheets/extra.css` | +430 lines (`.api-endpoint`, `.config-key`, `.def-card` with shared border/radius/copper-hover vocabulary, slate-mode variants, reduced-motion gates) |
| **HTTP API reference** | `docs/reference/http-api.md` | 30 endpoint cards + 4 JSONB filter cards |
| **Config reference** | `docs/configuration/reference.md` | 43 cards across 8 sections (server, oidc, api_keys, auth, database, audit, portal, tools) |
| **Env vars** | `docs/configuration/environment.md` | 11 env-var cards with `maps to` chips |
| **Audit page** | `docs/operations/audit.md` | column cards + 6 endpoint cards (the second table that was hidden below the JSONB filter section) |
| **Portal page** | `docs/operations/portal.md` | 10 route cards |
| **MCP reference** | `docs/reference/mcp.md` | 5 method cards |
| **Surface tables** | `docs/getting-started/{overview,quickstart}.md` | 7 + 4 def-cards |
| **Mermaid** | `docs/operations/gateway-testing.md` | 2 diagrams converted from ASCII |
| **Kubernetes example** | `examples/kubernetes/*.{yaml,sh,md}` (10 files) + `docs/operations/kubernetes.md` + `mkdocs.yml` nav + `docs/operations/deployment.md` cross-link | new |
| **SEO** | `docs/llms.txt`, `mkdocs.yml`, `.github/workflows/docs.yml` | inspection + kubernetes pages added; social plugin enabled in CI; cairo / freetype / libpng / libjpeg / libffi / libz dev packages installed for cairosvg + Pillow |

Total: 26 files, +3375 / −188.

## Card design vocabulary

Same shell as the carousel slides shipped in PR #12: 1px `--md-default-fg-color--lightest` border, `--plex-radius-md`, copper hover-tint with shadow lift. 3px left strip color-codes the entry's category:

- `.api-endpoint--get` → `--copper-400` (read, frequent)
- `.api-endpoint--post` → `--copper-700` (write)
- `.api-endpoint--delete` → coral `#b04829` (destructive but not traffic-light red)
- `.config-key--required` → deeper `--copper-700` (required-config has the same coral chip variant in the meta row, shared with the DELETE pill so destructive verbs and required-config-failures share one visual lookout)

Head row is a fixed two-row stack (`flex-direction: column`): identifier on row 1 at full row width (no wrap), `[label] value` chips on row 2 in the same horizontal slot every card. Description body sits below in DM Sans, indented under the identifier so the eye doesn't have to reset.

## Kubernetes example architecture

```
client → Ingress (nginx + cert-manager) → Deployment mcp-test → StatefulSet postgres
```

Manifests in `examples/kubernetes/`:

- Numeric prefix is the apply order (`00`, `10`, `12`, `14`, `20`, `25`, `30`, `40`, `50`).
- `install.sh` confirms the kubectl context, fills `REPLACE_ME_*` placeholders with `openssl rand` output on first run, applies in sequence with `[N/M]` progress, waits for `pod/postgres-0` Ready (180s) before applying mcp-test, waits for the Deployment rollout (180s).
- `mkdocs-material[imaging]`-driven social cards make the docs page itself shareable.

## Verification

- `mkdocs build --strict` ✅ (zero warnings, zero broken refs).
- `make verify` ✅ (Go suite untouched; ran for sentinel parity).
- All 9 K8s manifests pass `kubectl apply --dry-run=client`.
- Python script in the commit verifies every embedded YAML in `kubernetes.md` matches its on-disk source verbatim (no paraphrasing drift).
- Site-wide audit confirms 0 mid-token wraps remain on identifier-shaped backtick'd content.
- Browser-driven smoke test on the live `mkdocs serve` confirmed: card layouts render, chips lock to a fixed slot, mermaid renders in both themes, lightbox carousel still works (PR #12 shipped that; not regressed).

## Pre-commit gate

Three separate review rounds across the three commits, each verdict CLEAN. Findings caught in-tree before commit:

- **MAJOR:** YAML drift between `kubernetes.md` embeds and the on-disk manifests (paraphrased `valueFrom: {secretKeyRef: ...}`). Fixed: embeds are now byte-identical to the on-disk source.
- **MINOR:** em-dashes in CSS comments and `install.sh` header (project hard-rule violation). Fixed.
- **MINOR:** missing `libz-dev` in the social-plugin system-deps list (parity with mkdocs-material upstream). Fixed.
- **NIT:** indent inconsistency in a reduced-motion CSS block. Fixed.

## Test plan

- [ ] CI: Deploy Documentation workflow runs green on this branch's merge.
- [ ] On the deployed site, share `/operations/inspection/` to a Slack/Twitter test channel and confirm the 1200×630 social card renders with the Plexara colors and Outfit typography.
- [ ] Click a method pill / route / config key on the live `/configuration/reference/` page and confirm no horizontal scroll on a 1440px viewport, even for the longest identifier (`server.streamable.session_timeout`).
- [ ] Open `/operations/kubernetes/` and confirm each YAML block has a copy button (mkdocs-material default) and the file-path title displays correctly.
- [ ] `git clone && cd examples/kubernetes && INGRESS_HOST=test.example.com ./install.sh --dry-run` against a real cluster context.
- [ ] llms.txt: visit `https://mcp-test.plexara.io/llms.txt` post-merge, confirm the two new Operations bullets are present.