### PR TITLE
docs: align audit/auth/oidc config reference with code

### DIFF
--- a/configs/mcp-test.example.yaml
+++ b/configs/mcp-test.example.yaml
@@ -59,7 +59,10 @@ database:
 audit:
   enabled: true
   retention_days: 30
-  redact_keys: [password, token, secret, authorization, api_key, credentials, cookie]
+  # Case-insensitive substring match on tool-call argument keys and HTTP
+  # header names. Setting this replaces the default list entirely — it does
+  # not merge — so include the defaults below when extending it.
+  redact_keys: [password, token, secret, authorization, api_key, credentials, bearer, cookie, jwt, session_id, private_key, passwd]
   # Inspection / debugging capture: full request and response envelopes
   # land in the sibling audit_payloads table for portal drill-down. Set
   # capture_payloads to false to keep audit_events summary-only.

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -104,7 +104,7 @@ Required when OIDC is enabled.
 </div>
 </div>
 <div class="config-key__body" markdown>
-Required `aud` claim value.
+Optional `aud` claim enforcement. The example config uses `${MCPTEST_OIDC_AUDIENCE:-mcp-test}`. Leave the variable unset and clear `oidc.audience` if you want to skip audience validation.
 </div>
 </div>
 

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -255,16 +255,16 @@ The IdP's issuer URL. mcp-test fetches `<issuer>/.well-known/openid-configuratio
 </div>
 </div>
 
-<div class="config-key config-key--required" markdown>
+<div class="config-key" markdown>
 <div class="config-key__head">
 <code class="config-key__name">oidc.audience</code>
 <div class="config-key__chips">
 <span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">string</span></span>
-<span class="config-key__chip config-key__chip--required"><span class="config-key__chip-label">required when</span><span class="config-key__chip-value">oidc.enabled</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">""</code></span>
 </div>
 </div>
 <div class="config-key__body" markdown>
-Required `aud` claim value. Tokens that don't carry this audience are rejected.
+Optional `aud` claim enforcement. When non-empty, tokens whose `aud` doesn't match are rejected. When empty, the audience check is skipped entirely. The bundled Keycloak realm and `MCPTEST_OIDC_AUDIENCE` env interpolation default to `mcp-test`.
 </div>
 </div>
 
@@ -430,11 +430,11 @@ If true, missing credentials on `/mcp` resolve to a synthetic Anonymous identity
 <code class="config-key__name">auth.require_for_mcp</code>
 <div class="config-key__chips">
 <span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">bool</span></span>
-<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">true</code></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">false</code></span>
 </div>
 </div>
 <div class="config-key__body" markdown>
-Gate the `/` endpoint. Currently the auth gateway checks for credential *presence* and 401s without one (unless anonymous is allowed).
+Advisory toggle, currently not read by the binary. MCP-endpoint gating is governed by `auth.allow_anonymous` and the composed auth chain: with anonymous off and no matching credential, `MCPAuthGateway` returns 401 with an RFC 9728 `WWW-Authenticate` header regardless of this flag. Shipped configs still set it for forward compatibility.
 </div>
 </div>
 
@@ -443,11 +443,11 @@ Gate the `/` endpoint. Currently the auth gateway checks for credential *presenc
 <code class="config-key__name">auth.require_for_portal</code>
 <div class="config-key__chips">
 <span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">bool</span></span>
-<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">true</code></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">false</code></span>
 </div>
 </div>
 <div class="config-key__body" markdown>
-Gate every `/portal/*` and `/api/v1/*` route. The portal auth middleware is independent of `allow_anonymous`.
+Advisory toggle, currently not read by the binary. The portal API is always behind `pkg/httpsrv.PortalAuth` middleware; that middleware doesn't consult this flag. Setting it has no runtime effect today.
 </div>
 </div>
 
@@ -532,7 +532,11 @@ Audit-log behavior.
 audit:
   enabled: true
   retention_days: 30
-  redact_keys: [password, token, secret, authorization, cookie, api_key, credentials]
+  redact_keys: [password, token, secret, authorization, api_key, credentials, bearer, cookie, jwt, session_id, private_key, passwd]
+  capture_payloads: true
+  capture_headers: true
+  max_payload_bytes: 65536
+  max_notifications: 100
 ```
 
 <div class="config-keys" markdown>
@@ -542,11 +546,11 @@ audit:
 <code class="config-key__name">audit.enabled</code>
 <div class="config-key__chips">
 <span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">bool</span></span>
-<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">true</code></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">false</code></span>
 </div>
 </div>
 <div class="config-key__body" markdown>
-Disables the audit pipeline entirely when false (no rows written, no portal data).
+Master switch for the audit pipeline. When false, `audit.NoopLogger` is wired up — no rows are written and the portal Audit page has nothing to show. The shipped example, dev, and live configs all set this to `true` because audit is the headline feature of mcp-test; the Go zero-value default only takes effect if you author a fresh config without an `audit:` block.
 </div>
 </div>
 
@@ -568,11 +572,63 @@ Documented retention target. mcp-test does not currently auto-prune; deploy a cr
 <code class="config-key__name">audit.redact_keys</code>
 <div class="config-key__chips">
 <span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">[]string</span></span>
-<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">[password, token, secret, authorization, api_key, credentials]</code></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">[password, token, secret, authorization, api_key, credentials, bearer, cookie, jwt, session_id, private_key, passwd]</code></span>
 </div>
 </div>
 <div class="config-key__body" markdown>
-Case-insensitive substring match. Any tool-call argument key matching one of these gets its value replaced with `[redacted]` before the row is written.
+Case-insensitive substring match. Any tool-call argument key matching one of these gets its value replaced with `[redacted]` before the row is written. The same list is applied to HTTP header names by the `headers` tool. Extend it for domain-specific secret naming; setting it replaces the default, it does not merge.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">audit.capture_payloads</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">bool</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">true</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Controls whether the `audit_payloads` sibling row (full request/response envelope, captured notifications, error categories) is written alongside the `audit_events` summary. Off by default in privacy-sensitive deployments; on by default here because mcp-test is a test fixture and full visibility is the point. The portal Inspection drawer and replay endpoint require this to be on.
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">audit.capture_headers</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">bool</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">true</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Whether redacted HTTP request headers are included in the payload row. No effect when `capture_payloads` is false. Headers are passed through the same redaction list as parameter keys (case-insensitive substring match).
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">audit.max_payload_bytes</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">int</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">65536</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Per-side cap (request and response counted separately). Payloads beyond this are dropped and the corresponding `request_truncated` / `response_truncated` flag on the payload row is set. Raise this when testing tools that legitimately return large blobs (e.g. `sized_response` at high `size_bytes`).
+</div>
+</div>
+
+<div class="config-key" markdown>
+<div class="config-key__head">
+<code class="config-key__name">audit.max_notifications</code>
+<div class="config-key__chips">
+<span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">int</span></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">100</code></span>
+</div>
+</div>
+<div class="config-key__body" markdown>
+Caps the number of notifications stored per call in `audit_payloads.notifications`. The streaming tools (`progress`, `chatty`) can emit hundreds; raise or lower based on how much detail the operator needs in the portal's Inspection view.
 </div>
 </div>
 
@@ -637,11 +693,11 @@ At least 16 bytes, 32+ recommended. HMAC key for cookie signing.
 <code class="config-key__name">portal.cookie_secure</code>
 <div class="config-key__chips">
 <span class="config-key__chip"><span class="config-key__chip-label">type</span><span class="config-key__chip-value">bool</span></span>
-<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">true</code></span>
+<span class="config-key__chip config-key__chip--default"><span class="config-key__chip-label">default</span><code class="config-key__chip-value">false</code></span>
 </div>
 </div>
 <div class="config-key__body" markdown>
-Sets the `Secure` cookie attribute. Leave on in production; turn off for local HTTP-only dev.
+Sets the `Secure` cookie attribute on the portal session cookie and on the PKCE state cookie used during the OIDC login flow. The shipped example and live configs set this to `true`; the dev config leaves it `false` for plain-HTTP localhost browsing. Always `true` in production.
 </div>
 </div>
 

--- a/docs/operations/audit.md
+++ b/docs/operations/audit.md
@@ -19,6 +19,19 @@ As of v1.1.0 audit data lives in two tables joined 1:1 by event ID:
 
 Cascade delete on the foreign key keeps retention atomic: deleting an `audit_events` row drops its payload row in the same statement.
 
+### Capture knobs
+
+Four config keys under `audit:` control how much detail the payload row carries; see the [configuration reference](../configuration/reference.md#audit) for full definitions.
+
+| Key | Default | Effect |
+|---|---|---|
+| `audit.capture_payloads` | `true` | Master switch for the `audit_payloads` table. Off ⇒ summary-only mode; portal Inspection drawer and replay are disabled for those rows. |
+| `audit.capture_headers` | `true` | Include the redacted request headers blob in the payload row. |
+| `audit.max_payload_bytes` | `65536` | Per-side cap (request and response counted separately). Excess bytes are dropped and `request_truncated` / `response_truncated` is set on the payload row. |
+| `audit.max_notifications` | `100` | Caps notifications stored per call. The streaming tools can emit hundreds; tune to taste. |
+
+A privacy-sensitive deployment usually sets `capture_payloads: false` and accepts the loss of inspection fidelity. A reproducibility-focused deployment raises `max_payload_bytes` to whatever its largest test payload demands so truncation never silently happens.
+
 ## What gets recorded
 
 <div class="def-cards" markdown>
@@ -309,14 +322,20 @@ ORDER BY ts DESC;
 `audit.redact_keys` is a list of case-insensitive substrings.
 Tool-call argument keys matching any substring have their *values*
 replaced with `"[redacted]"` before the row is written. The default
-list includes `password`, `token`, `secret`, `authorization`,
-`cookie`, `api_key`, `credentials`.
+list is `password`, `token`, `secret`, `authorization`, `api_key`,
+`credentials`, `bearer`, `cookie`, `jwt`, `session_id`,
+`private_key`, `passwd`. Setting `redact_keys` replaces the default
+list entirely — it does not merge — so include the defaults when
+extending it.
 
 The match is on argument *keys*, not values. So an argument like
 `{"password": "hunter2"}` is redacted, but a free-text body that
 happens to contain the word "password" is not.
 
-Sanitization is recursive: nested objects and arrays are walked.
+Sanitization is recursive: nested objects and arrays are walked. The
+same list is also applied to HTTP header *names* by the `headers`
+tool, and to the redacted-headers blob captured into
+`audit_payloads.request_headers` when payload capture is on.
 
 ## Retention
 


### PR DESCRIPTION
## Summary

Sweep of `docs/configuration/reference.md` and friends against `pkg/config/config.go` after the v1.2 follow-ups. Four classes of drift fixed:

**Missing keys** — `audit.capture_payloads`, `audit.capture_headers`, `audit.max_payload_bytes`, `audit.max_notifications` were in `configs/mcp-test.example.yaml` and `pkg/config/config.go:152-174` but never documented in the reference page.

**Wrong defaults** — four boolean defaults said `true` in the reference, but `applyDefaults()` never touches them so the Go zero-value default is actually `false`:
- `audit.enabled`
- `portal.cookie_secure`
- `auth.require_for_mcp`
- `auth.require_for_portal`

The shipped example/dev/live configs all set these explicitly, so this never bites in shipped configs — but the reference was lying about the omit-this-key behavior. Corrected with notes about what each shipped config does.

**Wrong required-ness** — `oidc.audience` was flagged "required when oidc.enabled" but `pkg/auth/oidc.go:121` only enforces it when non-empty (`if v.cfg.Audience != ""`). Demoted to optional in both `reference.md` and `environment.md`.

**Honest documentation** — `auth.require_for_mcp` and `auth.require_for_portal` are declared in `AuthConfig` but read by nothing in the binary; gating is governed by `auth.allow_anonymous` and the composed auth chain. The reference previously claimed they "gated" endpoints. Now described as advisory with a pointer to what actually does the gating.

**Example YAML** — `configs/mcp-test.example.yaml` shipped a 7-key `redact_keys` list while `applyDefaults()` installs 12 keys. Operators copying the example would lose 5 defaults silently because setting `redact_keys` replaces rather than merges. Updated to the full 12-key list with a comment about the no-merge behavior.

## Test plan

- [ ] `mkdocs build --strict` succeeds
- [ ] Spot-check rendered Audit and Auth sections in the docs preview
- [ ] No code changes; no Go test impact

## Follow-up worth a separate PR

`auth.require_for_mcp` / `require_for_portal` are dead fields in `pkg/config/config.go:129-130`. Either wire them up (the test fixtures + example configs imply that was the intent) or delete them. Out of scope here — flagging for triage.