### PR TITLE
chore: bump Go toolchain to 1.26.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
           cache: true
 
       - name: Run golangci-lint
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
           cache: true
 
       - name: Verify go.mod is tidy
@@ -107,7 +107,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
           cache: true
 
       - name: Build
@@ -165,7 +165,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
           cache: true
 
       - name: gosec
@@ -176,7 +176,7 @@ jobs:
       - name: govulncheck
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
         with:
-          go-version-input: "1.26.2"
+          go-version-input: "1.26.3"
           repo-checkout: false
 
       - name: Semgrep
@@ -207,7 +207,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
           cache: true
 
       - name: Run integration tests

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
           cache: true
 
       - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
           cache: true
 
       - name: Set up Node (for SPA build)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/plexara/mcp-test
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1


### PR DESCRIPTION
## Summary

`govulncheck` flags two stdlib CVEs on the current `go 1.26.2` pin, blocking the Security CI job on any open PR (including #16):

- **GO-2026-4971** — `net.Dial` / `net.LookupPort` panic when given a NUL byte on Windows. Fixed in `net@go1.26.3`.
- **GO-2026-4918** — HTTP/2 transport infinite loop on bad `SETTINGS_MAX_FRAME_SIZE` in `net/http/internal/http2`. Fixed in `net/http@go1.26.3`.

Both advisories list `1.26.3` explicitly as the fix version, so the minimum-viable bump is one patch level. No application code changes.

## Changes

- `go.mod`: `go 1.26.2` → `go 1.26.3`
- `.github/workflows/ci.yml`: six `go-version: "1.26.2"` + one `go-version-input: "1.26.2"` → `1.26.3`
- `.github/workflows/codeql.yml`: `go-version` → `1.26.3`
- `.github/workflows/release.yml`: `go-version` → `1.26.3`

`Dockerfile.dev` is unchanged — it pins `golang:1.26-alpine` which floats minor patches automatically.

## Test plan

- [ ] CI Security job (govulncheck step) reports clean
- [ ] CI Test job still passes (no surface-area change between 1.26.2 and 1.26.3)
- [ ] CodeQL and integration jobs unchanged